### PR TITLE
feat(showcase): add ThemeComposer visual testing page

### DIFF
--- a/.changeset/cold-deer-drum.md
+++ b/.changeset/cold-deer-drum.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': minor
+---
+
+Add ThemeComposer showcase page for visual recipe testing

--- a/examples/expo-showcase/App.tsx
+++ b/examples/expo-showcase/App.tsx
@@ -1,4 +1,12 @@
-import { AppShell, Tabs, Toolbar, ToolbarAction, ZoraProvider } from '@ankhorage/zora';
+import {
+  AppShell,
+  Tabs,
+  Toolbar,
+  ToolbarAction,
+  ZoraProvider,
+  type ZoraTheme,
+  type ZoraThemeMode,
+} from '@ankhorage/zora';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { View } from 'react-native';
@@ -7,13 +15,23 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ComponentsPage } from './app/components';
 import { HomePage } from './app/home';
 import { PatternsPage } from './app/patterns';
+import { ThemeComposerPage } from './app/theme-composer';
 
-type ShowcaseTab = 'home' | 'components' | 'patterns';
-type ColorMode = 'light' | 'dark';
+type ShowcaseTab = 'home' | 'components' | 'patterns' | 'theme';
+type ColorMode = ZoraThemeMode;
+
+const initialShowcaseTheme = {
+  id: 'showcase',
+  name: 'Showcase',
+  primaryColor: '#0b6e99',
+  harmony: 'analogous',
+  colorTone: 'jewel',
+} satisfies ZoraTheme;
 
 function AppWrapper() {
   const [activeTab, setActiveTab] = React.useState<ShowcaseTab>('home');
   const [colorMode, setColorMode] = React.useState<ColorMode>('light');
+  const [showcaseTheme, setShowcaseTheme] = React.useState<ZoraTheme>(initialShowcaseTheme);
 
   const isDark = colorMode === 'dark';
 
@@ -29,23 +47,22 @@ function AppWrapper() {
         return <ComponentsPage />;
       case 'patterns':
         return <PatternsPage />;
+      case 'theme':
+        return (
+          <ThemeComposerPage
+            mode={colorMode}
+            onModeChange={setColorMode}
+            onThemeChange={setShowcaseTheme}
+            theme={showcaseTheme}
+          />
+        );
       default:
         return <HomePage onNavigate={setActiveTab} />;
     }
   };
 
   return (
-    <ZoraProvider
-      key={colorMode}
-      initialMode={colorMode}
-      theme={{
-        id: 'showcase',
-        name: 'Showcase',
-        primaryColor: '#0b6e99',
-        harmony: 'analogous',
-        colorTone: 'jewel',
-      }}
-    >
+    <ZoraProvider key={colorMode} initialMode={colorMode} theme={showcaseTheme}>
       <SafeAreaProvider>
         <StatusBar style={isDark ? 'light' : 'dark'} />
 
@@ -61,6 +78,7 @@ function AppWrapper() {
                   { value: 'home', label: 'Home' },
                   { value: 'components', label: 'Components' },
                   { value: 'patterns', label: 'Patterns' },
+                  { value: 'theme', label: 'Theme' },
                 ]}
               />
               <View style={{ flex: 1 }} />

--- a/examples/expo-showcase/app/home.tsx
+++ b/examples/expo-showcase/app/home.tsx
@@ -2,8 +2,10 @@ import { Badge, Button, Card, Page, PageHeader, PageSection } from '@ankhorage/z
 import React from 'react';
 import { ScrollView } from 'react-native';
 
+type ShowcaseTab = 'home' | 'components' | 'patterns' | 'theme';
+
 interface HomePageProps {
-  onNavigate: React.Dispatch<React.SetStateAction<'home' | 'components' | 'patterns'>>;
+  onNavigate: React.Dispatch<React.SetStateAction<ShowcaseTab>>;
 }
 
 export function HomePage({ onNavigate }: HomePageProps) {
@@ -14,7 +16,7 @@ export function HomePage({ onNavigate }: HomePageProps) {
           <PageHeader
             eyebrow="ZORA Showcase"
             title="Build polished Expo and React Native Web interfaces"
-            description="Explore ZORA components and scenario-based patterns in one small showcase app."
+            description="Explore ZORA components, scenario-based patterns, and live theme recipes in one small showcase app."
           />
         }
       >
@@ -39,6 +41,21 @@ export function HomePage({ onNavigate }: HomePageProps) {
               </Button>
             }
             footer={<Badge tone="success">Composed UI</Badge>}
+          />
+
+          <Card
+            title="Theme Composer"
+            description="Edit a ZORA theme seed live and inspect how colorTone, harmony, primary color, and mode affect real UI surfaces."
+            actions={
+              <Button size="s" onPress={() => onNavigate('theme')}>
+                Open theme lab
+              </Button>
+            }
+            footer={
+              <Badge tone="warning" emphasis="soft">
+                Theme lab
+              </Badge>
+            }
           />
         </PageSection>
       </Page>

--- a/examples/expo-showcase/app/theme-composer.tsx
+++ b/examples/expo-showcase/app/theme-composer.tsx
@@ -1,0 +1,233 @@
+import { Stack } from '@ankhorage/surface';
+import {
+  Badge,
+  Button,
+  Card,
+  EmptyState,
+  Input,
+  Notice,
+  Page,
+  PageHeader,
+  PageSection,
+  Panel,
+  Tabs,
+  Text,
+  Textarea,
+  ThemeComposer,
+  Toolbar,
+  ToolbarAction,
+  ZoraThemeScope,
+  type ZoraTheme,
+  type ZoraThemeMode,
+} from '@ankhorage/zora';
+import React from 'react';
+import { ScrollView, View } from 'react-native';
+
+interface ThemeComposerPageProps {
+  theme: ZoraTheme;
+  mode: ZoraThemeMode;
+  onThemeChange: (theme: ZoraTheme) => void;
+  onModeChange: (mode: ZoraThemeMode) => void;
+}
+
+const recipeThemes = [
+  {
+    label: 'Pastel + jewel',
+    theme: {
+      id: 'showcase-pastel-jewel',
+      name: 'Pastel jewel',
+      primaryColor: '#c084fc',
+      harmony: 'analogous',
+      colorTone: 'pastel',
+    } satisfies ZoraTheme,
+  },
+  {
+    label: 'Obsidian + fluorescent',
+    theme: {
+      id: 'showcase-obsidian-fluorescent',
+      name: 'Obsidian fluorescent',
+      primaryColor: '#22d3ee',
+      harmony: 'splitComplementary',
+      colorTone: 'obsidian',
+    } satisfies ZoraTheme,
+  },
+  {
+    label: 'Earth + mineral',
+    theme: {
+      id: 'showcase-earth-mineral',
+      name: 'Earth mineral',
+      primaryColor: '#78716c',
+      harmony: 'analogous',
+      colorTone: 'earth',
+    } satisfies ZoraTheme,
+  },
+  {
+    label: 'Vaporwave + fluorescent',
+    theme: {
+      id: 'showcase-vaporwave-fluorescent',
+      name: 'Vaporwave fluorescent',
+      primaryColor: '#ec4899',
+      harmony: 'splitComplementary',
+      colorTone: 'vaporwave',
+    } satisfies ZoraTheme,
+  },
+  {
+    label: 'Neutral + jewel',
+    theme: {
+      id: 'showcase-neutral-jewel',
+      name: 'Neutral jewel',
+      primaryColor: '#2563eb',
+      harmony: 'triadic',
+      colorTone: 'jewel',
+    } satisfies ZoraTheme,
+  },
+] as const;
+
+export function ThemeComposerPage({
+  theme,
+  mode,
+  onThemeChange,
+  onModeChange,
+}: ThemeComposerPageProps) {
+  const [previewTab, setPreviewTab] = React.useState('overview');
+
+  return (
+    <ScrollView>
+      <Page
+        header={
+          <PageHeader
+            eyebrow="Theme lab"
+            title="Theme Composer"
+            description="Edit the active ZORA theme seed and inspect how primary color, harmony, color tone, and mode affect real UI surfaces."
+          />
+        }
+      >
+        <PageSection title="Composer">
+          <ThemeComposer
+            value={theme}
+            onChange={onThemeChange}
+            mode={mode}
+            onModeChange={onModeChange}
+          />
+        </PageSection>
+
+        <PageSection title="Recipe presets">
+          <Stack direction="row" gap="s" wrap="wrap">
+            {recipeThemes.map((preset) => (
+              <Button
+                key={preset.theme.id}
+                emphasis={theme.id === preset.theme.id ? 'solid' : 'soft'}
+                size="s"
+                tone="primary"
+                onPress={() => onThemeChange(preset.theme)}
+              >
+                {preset.label}
+              </Button>
+            ))}
+          </Stack>
+        </PageSection>
+
+        <ZoraThemeScope mode={mode}>
+          <PageSection title="Live preview">
+            <Notice
+              title="Preview follows the active theme"
+              description="The whole showcase app receives the edited theme seed. This preview also scopes light and dark mode without relying on provider remounts."
+              tone="primary"
+            />
+
+            <Panel
+              title="Surface area"
+              description="Panel, toolbar, cards, badges, form controls, and navigation should remain legible across the target recipe combinations."
+            >
+              <Stack gap="m">
+                <Toolbar position="inline">
+                  <ToolbarAction active icon={{ name: 'color-palette-outline' }} label="Design" />
+                  <ToolbarAction icon={{ name: 'sparkles-outline' }} label="Generate" />
+                  <ToolbarAction icon={{ name: 'eye-outline' }} label="Preview" />
+                  <View style={{ flex: 1 }} />
+                  <ToolbarAction icon={{ name: 'save-outline' }} label="Save" />
+                </Toolbar>
+
+                <Tabs
+                  value={previewTab}
+                  onValueChange={setPreviewTab}
+                  variant="segmented"
+                  items={[
+                    { value: 'overview', label: 'Overview' },
+                    { value: 'inputs', label: 'Inputs' },
+                    { value: 'states', label: 'States' },
+                  ]}
+                />
+
+                <Card
+                  title="App dashboard"
+                  description="A representative content card with actions and mixed badge tones."
+                  actions={
+                    <Button size="s" trailingIcon={{ name: 'arrow-forward-outline' }}>
+                      Continue
+                    </Button>
+                  }
+                  footer={
+                    <Stack direction="row" gap="s" wrap="wrap">
+                      <Badge tone="primary">Primary</Badge>
+                      <Badge tone="success" emphasis="soft">
+                        Success
+                      </Badge>
+                      <Badge tone="warning" emphasis="soft">
+                        Warning
+                      </Badge>
+                      <Badge tone="danger" emphasis="outline">
+                        Danger
+                      </Badge>
+                    </Stack>
+                  }
+                >
+                  <Stack gap="s">
+                    <Text variant="lead" tone="muted">
+                      The active seed is {theme.colorTone} with {theme.harmony} harmony.
+                    </Text>
+                    <Text>
+                      Use this surface to catch contrast, tint, nested card, and action-color issues before generated apps consume the theme.
+                    </Text>
+                  </Stack>
+                </Card>
+
+                <Card
+                  title="Form controls"
+                  description="Inputs and textareas should stay readable on themed surfaces."
+                  tone="subtle"
+                >
+                  <Stack gap="s">
+                    <Input value={theme.primaryColor} />
+                    <Textarea
+                      value="Theme notes, accessibility observations, and recipe QA details."
+                      rows={3}
+                    />
+                    <Stack direction="row" gap="s" wrap="wrap">
+                      <Button tone="primary">Primary action</Button>
+                      <Button tone="neutral" emphasis="soft">
+                        Secondary
+                      </Button>
+                      <Button tone="danger" emphasis="ghost">
+                        Danger ghost
+                      </Button>
+                    </Stack>
+                  </Stack>
+                </Card>
+              </Stack>
+            </Panel>
+          </PageSection>
+
+          <PageSection title="Empty state preview">
+            <EmptyState
+              title="No generated screens yet"
+              description="Empty states should use subtle theme tinting without losing text contrast or action clarity."
+              primaryAction={{ label: 'Generate screen', onPress: () => undefined }}
+              secondaryAction={{ label: 'Import template', onPress: () => undefined }}
+            />
+          </PageSection>
+        </ZoraThemeScope>
+      </Page>
+    </ScrollView>
+  );
+}

--- a/examples/expo-showcase/app/theme-composer.tsx
+++ b/examples/expo-showcase/app/theme-composer.tsx
@@ -16,9 +16,9 @@ import {
   ThemeComposer,
   Toolbar,
   ToolbarAction,
-  ZoraThemeScope,
   type ZoraTheme,
   type ZoraThemeMode,
+  ZoraThemeScope,
 } from '@ankhorage/zora';
 import React from 'react';
 import { ScrollView, View } from 'react-native';
@@ -187,7 +187,8 @@ export function ThemeComposerPage({
                       The active seed is {theme.colorTone} with {theme.harmony} harmony.
                     </Text>
                     <Text>
-                      Use this surface to catch contrast, tint, nested card, and action-color issues before generated apps consume the theme.
+                      Use this surface to catch contrast, tint, nested card, and action-color issues
+                      before generated apps consume the theme.
                     </Text>
                   </Stack>
                 </Card>


### PR DESCRIPTION
## Summary

Adds the issue #75 ThemeComposer showcase page to the Expo showcase app.

- Adds a new `Theme` tab to the showcase navigation.
- Lifts the showcase `ZoraTheme` seed into `AppWrapper` so `ThemeComposer` edits update the active provider theme.
- Adds a dedicated `ThemeComposerPage` with live seed editing for `primaryColor`, `harmony`, `colorTone`, and `mode`.
- Adds recipe preset buttons for the requested visual combinations:
  - pastel background + jewel foreground
  - obsidian background + fluorescent foreground
  - earth background + mineral foreground
  - vaporwave background + fluorescent foreground
  - neutral background + jewel foreground
- Adds a live preview area covering page/surface context, panel, card, toolbar, tabs, buttons, badges, inputs, textarea, notice, and empty state.

## Notes

The preview wraps the live surface area in `ZoraThemeScope mode={mode}` so mode changes can be visually tested without relying only on `ZoraProvider initialMode` remount behavior.

## Verification

Not run locally from this environment. GitHub CI should run on the PR.