### PR TITLE
feat(theme): add ThemeComposer recommendations

### DIFF
--- a/.changeset/theme-composer-recommendations.md
+++ b/.changeset/theme-composer-recommendations.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': minor
+---
+
+Add optional ThemeComposer recommendation props and explicit recommendation application UI.

--- a/src/patterns/theme-composer/ThemeComposer.test.ts
+++ b/src/patterns/theme-composer/ThemeComposer.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from 'bun:test';
 
 import { ZORA_COLOR_HARMONIES, ZORA_COLOR_TONES } from '../../theme/types';
 import { zoraDefaultTheme } from '../../theme/zoraDefaultTheme';
-import type { ThemeComposerProps } from './types';
+import {
+  createThemeFromThemeComposerRecommendation,
+  findThemeComposerRecommendation,
+  formatThemeComposerLabel,
+  hueDegreesToZoraHexColor,
+} from './recommendations';
+import type { ThemeComposerProps, ThemeComposerRecommendation } from './types';
 
 // Validate the exported types compile correctly by asserting shape
 describe('ThemeComposerProps', () => {
@@ -37,6 +43,25 @@ describe('ThemeComposerProps', () => {
     };
     props.onSubmit?.(zoraDefaultTheme);
     expect(submitted).toBe(true);
+  });
+
+  test('accepts optional recommendation inputs', () => {
+    const recommendation: ThemeComposerRecommendation = {
+      appCategory: 'finance_money',
+      appMood: 'trustworthy',
+      suggestedColorTone: 'mineral',
+      suggestedHarmony: 'analogous',
+      suggestedPrimaryHueDegrees: 195,
+    };
+    const props: ThemeComposerProps = {
+      value: zoraDefaultTheme,
+      onChange: () => undefined,
+      appCategory: 'finance_money',
+      appMood: 'trustworthy',
+      recommendations: [recommendation],
+    };
+
+    expect(props.recommendations?.[0]?.suggestedColorTone).toBe('mineral');
   });
 });
 
@@ -74,7 +99,7 @@ describe('ZORA_COLOR_TONES coverage for ThemeComposer', () => {
 
 describe('onChange propagation contract', () => {
   test('onChange receives updated theme with new harmony', () => {
-    const received: unknown[] = [];
+    const received: typeof zoraDefaultTheme[] = [];
     const props: ThemeComposerProps = {
       value: zoraDefaultTheme,
       onChange: (t) => received.push(t),
@@ -82,16 +107,96 @@ describe('onChange propagation contract', () => {
     // Simulate what the component does internally
     props.onChange({ ...zoraDefaultTheme, harmony: 'triadic' });
     expect(received).toHaveLength(1);
-    expect((received[0] as typeof zoraDefaultTheme).harmony).toBe('triadic');
+    expect(received[0]?.harmony).toBe('triadic');
   });
 
   test('onChange receives updated theme with new colorTone', () => {
-    const received: unknown[] = [];
+    const received: typeof zoraDefaultTheme[] = [];
     const props: ThemeComposerProps = {
       value: zoraDefaultTheme,
       onChange: (t) => received.push(t),
     };
     props.onChange({ ...zoraDefaultTheme, colorTone: 'obsidian' });
-    expect((received[0] as typeof zoraDefaultTheme).colorTone).toBe('obsidian');
+    expect(received[0]?.colorTone).toBe('obsidian');
+  });
+});
+
+describe('ThemeComposer recommendation helpers', () => {
+  const recommendations: readonly ThemeComposerRecommendation[] = [
+    {
+      appCategory: 'finance_money',
+      appMood: 'trustworthy',
+      suggestedColorTone: 'mineral',
+      suggestedHarmony: 'analogous',
+      suggestedPrimaryHueDegrees: 195,
+    },
+    {
+      appCategory: 'graphics_design',
+      appMood: 'creative',
+      suggestedColorTone: 'vaporwave',
+      suggestedHarmony: 'splitComplementary',
+    },
+  ];
+
+  test('finds a recommendation by app category and mood', () => {
+    const found = findThemeComposerRecommendation({
+      appCategory: 'finance_money',
+      appMood: 'trustworthy',
+      recommendations,
+    });
+
+    expect(found?.suggestedColorTone).toBe('mineral');
+  });
+
+  test('does not find a recommendation with mismatched mood', () => {
+    const found = findThemeComposerRecommendation({
+      appCategory: 'finance_money',
+      appMood: 'creative',
+      recommendations,
+    });
+
+    expect(found).toBeUndefined();
+  });
+
+  test('creates an updated theme only when recommendation is explicitly applied', () => {
+    const recommendation = recommendations[0];
+    if (recommendation === undefined) {
+      throw new Error('Expected fixture recommendation.');
+    }
+
+    const updated = createThemeFromThemeComposerRecommendation({
+      value: zoraDefaultTheme,
+      recommendation,
+    });
+
+    expect(zoraDefaultTheme.colorTone).toBe('jewel');
+    expect(updated.colorTone).toBe('mineral');
+    expect(updated.harmony).toBe('analogous');
+    expect(updated.primaryColor).not.toBe(zoraDefaultTheme.primaryColor);
+  });
+
+  test('keeps the current primary color when recommendation has no hue', () => {
+    const recommendation = recommendations[1];
+    if (recommendation === undefined) {
+      throw new Error('Expected fixture recommendation.');
+    }
+
+    const updated = createThemeFromThemeComposerRecommendation({
+      value: zoraDefaultTheme,
+      recommendation,
+    });
+
+    expect(updated.primaryColor).toBe(zoraDefaultTheme.primaryColor);
+    expect(updated.colorTone).toBe('vaporwave');
+  });
+
+  test('formats serialized labels for display', () => {
+    expect(formatThemeComposerLabel('finance_money')).toBe('Finance money');
+    expect(formatThemeComposerLabel('splitComplementary')).toBe('Split Complementary');
+  });
+
+  test('converts hue degrees to lowercase hex', () => {
+    expect(hueDegreesToZoraHexColor(195)).toMatch(/^#[0-9a-f]{6}$/);
+    expect(hueDegreesToZoraHexColor(555)).toBe(hueDegreesToZoraHexColor(195));
   });
 });

--- a/src/patterns/theme-composer/ThemeComposer.test.ts
+++ b/src/patterns/theme-composer/ThemeComposer.test.ts
@@ -99,7 +99,7 @@ describe('ZORA_COLOR_TONES coverage for ThemeComposer', () => {
 
 describe('onChange propagation contract', () => {
   test('onChange receives updated theme with new harmony', () => {
-    const received: typeof zoraDefaultTheme[] = [];
+    const received: (typeof zoraDefaultTheme)[] = [];
     const props: ThemeComposerProps = {
       value: zoraDefaultTheme,
       onChange: (t) => received.push(t),
@@ -111,7 +111,7 @@ describe('onChange propagation contract', () => {
   });
 
   test('onChange receives updated theme with new colorTone', () => {
-    const received: typeof zoraDefaultTheme[] = [];
+    const received: (typeof zoraDefaultTheme)[] = [];
     const props: ThemeComposerProps = {
       value: zoraDefaultTheme,
       onChange: (t) => received.push(t),
@@ -159,7 +159,7 @@ describe('ThemeComposer recommendation helpers', () => {
   });
 
   test('creates an updated theme only when recommendation is explicitly applied', () => {
-    const recommendation = recommendations[0];
+    const [recommendation] = recommendations;
     if (recommendation === undefined) {
       throw new Error('Expected fixture recommendation.');
     }
@@ -176,7 +176,7 @@ describe('ThemeComposer recommendation helpers', () => {
   });
 
   test('keeps the current primary color when recommendation has no hue', () => {
-    const recommendation = recommendations[1];
+    const [, recommendation] = recommendations;
     if (recommendation === undefined) {
       throw new Error('Expected fixture recommendation.');
     }

--- a/src/patterns/theme-composer/ThemeComposer.tsx
+++ b/src/patterns/theme-composer/ThemeComposer.tsx
@@ -18,6 +18,11 @@ import {
 } from '../../theme/types';
 import { useZoraTheme } from '../../theme/useZoraTheme';
 import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import {
+  createThemeFromThemeComposerRecommendation,
+  findThemeComposerRecommendation,
+  formatThemeComposerLabel,
+} from './recommendations';
 import type { ThemeComposerProps } from './types';
 
 const HEX_RE = /^#[0-9A-Fa-f]{6}$/;
@@ -68,6 +73,9 @@ function ThemeComposerInner({
   mode,
   onModeChange,
   onSubmit,
+  appCategory,
+  appMood,
+  recommendations,
   testID,
 }: ThemeComposerProps) {
   const { theme } = useZoraTheme();
@@ -95,9 +103,63 @@ function ThemeComposerInner({
   }
 
   const activeMode = mode ?? 'light';
+  const recommendation = findThemeComposerRecommendation({
+    appCategory,
+    appMood,
+    recommendations,
+  });
 
   return (
     <Stack gap="l" testID={testID}>
+      {recommendation ? (
+        <Card
+          title="Recommended starting point"
+          description="Use this as an optional starting point. It is only applied when you choose it."
+          actions={
+            <Button
+              size="s"
+              emphasis="soft"
+              tone="primary"
+              onPress={() =>
+                onChange(
+                  createThemeFromThemeComposerRecommendation({
+                    value,
+                    recommendation,
+                  }),
+                )
+              }
+              testID={testID ? `${testID}-apply-recommendation` : undefined}
+            >
+              Apply recommendation
+            </Button>
+          }
+        >
+          <Stack gap="s">
+            <Stack direction="row" gap="s" wrap="wrap">
+              <Badge tone="primary" emphasis="soft">
+                {formatThemeComposerLabel(recommendation.appMood)} mood
+              </Badge>
+              <Badge tone="neutral" emphasis="soft">
+                {formatThemeComposerLabel(recommendation.suggestedColorTone)} color tone
+              </Badge>
+              <Badge tone="neutral" emphasis="soft">
+                {formatThemeComposerLabel(recommendation.suggestedHarmony)} harmony
+              </Badge>
+              {recommendation.suggestedPrimaryHueDegrees === undefined ? null : (
+                <Badge tone="neutral" emphasis="soft">
+                  {recommendation.suggestedPrimaryHueDegrees}° hue
+                </Badge>
+              )}
+            </Stack>
+            <Text tone="muted" variant="bodySmall">
+              Suggested for {formatThemeComposerLabel(recommendation.appCategory)}. The color tone
+              controls palette character, harmony controls accent relationships, and hue sets the
+              starting primary color when available.
+            </Text>
+          </Stack>
+        </Card>
+      ) : null}
+
       {/* Section: Primary Color */}
       <Card title="Primary color" description="Set the seed color for your theme palette.">
         <Stack gap="m">

--- a/src/patterns/theme-composer/index.ts
+++ b/src/patterns/theme-composer/index.ts
@@ -1,2 +1,7 @@
 export { ThemeComposer } from './ThemeComposer';
-export type { ThemeComposerProps } from './types';
+export type {
+  ThemeComposerAppCategory,
+  ThemeComposerAppMood,
+  ThemeComposerProps,
+  ThemeComposerRecommendation,
+} from './types';

--- a/src/patterns/theme-composer/recommendations.ts
+++ b/src/patterns/theme-composer/recommendations.ts
@@ -1,0 +1,85 @@
+import type { ZoraHexColor, ZoraTheme } from '../../theme/types';
+import type {
+  ThemeComposerAppCategory,
+  ThemeComposerAppMood,
+  ThemeComposerRecommendation,
+} from './types';
+
+export function findThemeComposerRecommendation(options: {
+  appCategory?: ThemeComposerAppCategory;
+  appMood?: ThemeComposerAppMood;
+  recommendations?: readonly ThemeComposerRecommendation[];
+}): ThemeComposerRecommendation | undefined {
+  if (options.appCategory === undefined || options.recommendations === undefined) {
+    return undefined;
+  }
+
+  return options.recommendations.find(
+    (recommendation) =>
+      recommendation.appCategory === options.appCategory &&
+      (options.appMood === undefined || recommendation.appMood === options.appMood),
+  );
+}
+
+export function formatThemeComposerLabel(value: string): string {
+  const spaced = value
+    .replace(/_/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .trim();
+
+  if (spaced.length === 0) {
+    return value;
+  }
+
+  return `${spaced.slice(0, 1).toUpperCase()}${spaced.slice(1)}`;
+}
+
+export function hueDegreesToZoraHexColor(hueDegrees: number): ZoraHexColor {
+  const normalizedHue = ((hueDegrees % 360) + 360) % 360;
+  const chroma = 0.56;
+  const lightness = 0.46;
+  const second = chroma * (1 - Math.abs(((normalizedHue / 60) % 2) - 1));
+  const match = lightness - chroma / 2;
+
+  const hueSector = Math.floor(normalizedHue / 60);
+  const [redPrime, greenPrime, bluePrime] = (() => {
+    switch (hueSector) {
+      case 0:
+        return [chroma, second, 0] as const;
+      case 1:
+        return [second, chroma, 0] as const;
+      case 2:
+        return [0, chroma, second] as const;
+      case 3:
+        return [0, second, chroma] as const;
+      case 4:
+        return [second, 0, chroma] as const;
+      default:
+        return [chroma, 0, second] as const;
+    }
+  })();
+
+  const toHexChannel = (channel: number): string => {
+    const value = Math.round(Math.min(1, Math.max(0, channel + match)) * 255);
+    return value.toString(16).padStart(2, '0');
+  };
+
+  return `#${toHexChannel(redPrime)}${toHexChannel(greenPrime)}${toHexChannel(bluePrime)}`;
+}
+
+export function createThemeFromThemeComposerRecommendation(options: {
+  value: ZoraTheme;
+  recommendation: ThemeComposerRecommendation;
+}): ZoraTheme {
+  const suggestedPrimaryColor =
+    options.recommendation.suggestedPrimaryHueDegrees === undefined
+      ? options.value.primaryColor
+      : hueDegreesToZoraHexColor(options.recommendation.suggestedPrimaryHueDegrees);
+
+  return {
+    ...options.value,
+    primaryColor: suggestedPrimaryColor,
+    harmony: options.recommendation.suggestedHarmony,
+    colorTone: options.recommendation.suggestedColorTone,
+  };
+}

--- a/src/patterns/theme-composer/types.ts
+++ b/src/patterns/theme-composer/types.ts
@@ -1,5 +1,21 @@
-import type { ZoraTheme, ZoraThemeMode } from '../../theme/types';
+import type {
+  ZoraColorHarmony,
+  ZoraColorTone,
+  ZoraTheme,
+  ZoraThemeMode,
+} from '../../theme/types';
 import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export type ThemeComposerAppCategory = string;
+export type ThemeComposerAppMood = string;
+
+export interface ThemeComposerRecommendation {
+  appCategory: ThemeComposerAppCategory;
+  appMood: ThemeComposerAppMood;
+  suggestedColorTone: ZoraColorTone;
+  suggestedHarmony: ZoraColorHarmony;
+  suggestedPrimaryHueDegrees?: number;
+}
 
 export interface ThemeComposerProps extends ZoraBaseProps {
   value: ZoraTheme;
@@ -7,4 +23,7 @@ export interface ThemeComposerProps extends ZoraBaseProps {
   mode?: ZoraThemeMode;
   onModeChange?: (mode: ZoraThemeMode) => void;
   onSubmit?: (theme: ZoraTheme) => void;
+  appCategory?: ThemeComposerAppCategory;
+  appMood?: ThemeComposerAppMood;
+  recommendations?: readonly ThemeComposerRecommendation[];
 }

--- a/src/patterns/theme-composer/types.ts
+++ b/src/patterns/theme-composer/types.ts
@@ -1,9 +1,4 @@
-import type {
-  ZoraColorHarmony,
-  ZoraColorTone,
-  ZoraTheme,
-  ZoraThemeMode,
-} from '../../theme/types';
+import type { ZoraColorHarmony, ZoraColorTone, ZoraTheme, ZoraThemeMode } from '../../theme/types';
 import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 
 export type ThemeComposerAppCategory = string;


### PR DESCRIPTION
## Summary

Closes #77.

Adds optional recommendation support to `ThemeComposer` without adding a direct `@ankhorage/contracts` dependency to ZORA.

- adds structural recommendation props to `ThemeComposerProps`
- shows a `Recommended starting point` panel when a matching recommendation is provided
- keeps recommendations opt-in: values are only applied through an explicit `Apply recommendation` action
- explains the suggested app mood, color tone, harmony, and optional primary hue
- adds helper tests for recommendation selection and application behavior
- exports the new recommendation-related ThemeComposer types
- adds a minor changeset

## Design note

The props are structurally compatible with the Contracts `AppCategoryThemeRecommendation` shape, but ZORA does not import Contracts directly. This keeps ZORA independent while allowing callers to pass contract recommendation objects.

## Verification

Not run locally from this environment. GitHub CI should run on the PR.