### PR TITLE
docs(showcase): refresh expo showcase coverage

### DIFF
--- a/.changeset/fresh-showcase-cats.md
+++ b/.changeset/fresh-showcase-cats.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Refresh Expo showcase coverage and add a policy test for app-facing ZORA imports.

--- a/examples/expo-showcase/app/components.tsx
+++ b/examples/expo-showcase/app/components.tsx
@@ -1,4 +1,3 @@
-import { Stack } from '@ankhorage/surface';
 import {
   Badge,
   Button,
@@ -15,6 +14,7 @@ import {
   RadioGroup,
   SectionHeader,
   Select,
+  Stack,
   Tabs,
   Text,
   Textarea,
@@ -23,6 +23,10 @@ import {
 } from '@ankhorage/zora';
 import React from 'react';
 import { ScrollView, View } from 'react-native';
+
+import { ComponentFormsSection } from './sections/componentForms';
+import { FoundationPrimitivesSection } from './sections/foundationPrimitives';
+import { LayoutsShowcaseSection } from './sections/layoutsShowcase';
 
 export function ComponentsPage() {
   const [tab, setTab] = React.useState('overview');
@@ -45,6 +49,8 @@ export function ComponentsPage() {
           />
         }
       >
+        <FoundationPrimitivesSection />
+
         <PageSection title="Typography">
           <SectionHeader
             title="Headings"
@@ -317,6 +323,8 @@ export function ComponentsPage() {
           />
         </PageSection>
 
+        <ComponentFormsSection />
+
         <PageSection title="Cards">
           <SectionHeader
             title="Common card layouts"
@@ -351,6 +359,8 @@ export function ComponentsPage() {
             description="Use subtle cards for secondary content or nested regions."
           />
         </PageSection>
+
+        <LayoutsShowcaseSection />
 
         <PageSection title="Overlays">
           <SectionHeader

--- a/examples/expo-showcase/app/patterns.tsx
+++ b/examples/expo-showcase/app/patterns.tsx
@@ -24,6 +24,8 @@ import {
 import React from 'react';
 import { ScrollView } from 'react-native';
 
+import { PatternGapsSection } from './sections/patternGaps';
+
 interface LayoutSection {
   id: string;
   name: string;
@@ -275,6 +277,8 @@ export function PatternsPage() {
             }}
           />
         </PageSection>
+
+        <PatternGapsSection />
       </Page>
     </ScrollView>
   );

--- a/examples/expo-showcase/app/sections/componentForms.tsx
+++ b/examples/expo-showcase/app/sections/componentForms.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 export function ComponentFormsSection() {
   const [standaloneChecked, setStandaloneChecked] = React.useState(false);
   const [standaloneRadioChecked, setStandaloneRadioChecked] = React.useState(true);
-  const [formValues, setFormValues] = React.useState({
+  const [formValues, setFormValues] = React.useState<Record<string, string>>({
     email: 'hello@example.com',
     project: 'Showcase refresh',
   });
@@ -52,7 +52,10 @@ export function ComponentFormsSection() {
         </Inline>
       </Card>
 
-      <Card title="Form wrapper" description="Compact coverage for Form, FormField, FormActions, and FormError.">
+      <Card
+        title="Form wrapper"
+        description="Compact coverage for Form, FormField, FormActions, and FormError."
+      >
         <Stack gap="m">
           <Form
             fields={[

--- a/examples/expo-showcase/app/sections/componentForms.tsx
+++ b/examples/expo-showcase/app/sections/componentForms.tsx
@@ -44,7 +44,10 @@ export function ComponentFormsSection() {
         </Stack>
       </Card>
 
-      <Card title="Plain Icon" description="Icon is useful for metadata and decorative affordances.">
+      <Card
+        title="Plain Icon"
+        description="Icon is useful for metadata and decorative affordances."
+      >
         <Inline gap="m">
           <Icon name="sparkles-outline" size={18} />
           <Icon name="color-palette-outline" size={24} />

--- a/examples/expo-showcase/app/sections/componentForms.tsx
+++ b/examples/expo-showcase/app/sections/componentForms.tsx
@@ -1,0 +1,98 @@
+import {
+  Button,
+  Card,
+  Checkbox,
+  Form,
+  FormActions,
+  FormError,
+  FormField,
+  Icon,
+  Inline,
+  Input,
+  PageSection,
+  Radio,
+  Stack,
+  Text,
+} from '@ankhorage/zora';
+import React from 'react';
+
+export function ComponentFormsSection() {
+  const [standaloneChecked, setStandaloneChecked] = React.useState(false);
+  const [standaloneRadioChecked, setStandaloneRadioChecked] = React.useState(true);
+  const [formValues, setFormValues] = React.useState({
+    email: 'hello@example.com',
+    project: 'Showcase refresh',
+  });
+
+  return (
+    <PageSection title="Component coverage additions">
+      <Card
+        title="Standalone Checkbox and Radio"
+        description="Single controls are available outside grouped inputs."
+      >
+        <Stack gap="s">
+          <Checkbox checked={standaloneChecked} onCheckedChange={setStandaloneChecked}>
+            Standalone checkbox
+          </Checkbox>
+          <Checkbox checked disabled>
+            Disabled checked checkbox
+          </Checkbox>
+          <Radio checked={standaloneRadioChecked} onCheckedChange={setStandaloneRadioChecked}>
+            Standalone radio
+          </Radio>
+          <Radio disabled>Disabled radio</Radio>
+        </Stack>
+      </Card>
+
+      <Card title="Plain Icon" description="Icon is useful for metadata and decorative affordances.">
+        <Inline gap="m">
+          <Icon name="sparkles-outline" size={18} />
+          <Icon name="color-palette-outline" size={24} />
+          <Icon name="rocket-outline" size={32} />
+        </Inline>
+      </Card>
+
+      <Card title="Form wrapper" description="Compact coverage for Form, FormField, FormActions, and FormError.">
+        <Stack gap="m">
+          <Form
+            fields={[
+              {
+                name: 'email',
+                label: 'Email',
+                type: 'email',
+                placeholder: 'hello@example.com',
+                rules: [{ kind: 'required' }, { kind: 'email' }],
+              },
+              {
+                name: 'project',
+                label: 'Project name',
+                placeholder: 'Showcase refresh',
+              },
+            ]}
+            values={formValues}
+            onChange={setFormValues}
+            onSubmit={() => undefined}
+            error="Example form-level error"
+            submitLabel="Save form"
+          />
+
+          <FormField label="Manual FormField" helperText="Useful when a custom control is needed.">
+            <Input placeholder="Manual field input" />
+          </FormField>
+
+          <FormError error="Standalone FormError coverage" />
+
+          <FormActions submitLabel="Save manually" onSubmit={() => undefined}>
+            <Button emphasis="ghost" tone="neutral">
+              Cancel
+            </Button>
+          </FormActions>
+
+          <Text tone="muted" variant="bodySmall">
+            Form values: {formValues.email} / {formValues.project}
+          </Text>
+        </Stack>
+      </Card>
+    </PageSection>
+  );
+}

--- a/examples/expo-showcase/app/sections/foundationPrimitives.tsx
+++ b/examples/expo-showcase/app/sections/foundationPrimitives.tsx
@@ -44,7 +44,10 @@ export function FoundationPrimitivesSection() {
         </Stack>
       </Card>
 
-      <Card title="Grid and Container" description="Responsive containers and grids keep catalog surfaces aligned.">
+      <Card
+        title="Grid and Container"
+        description="Responsive containers and grids keep catalog surfaces aligned."
+      >
         <Container maxWidth={720} px="s">
           <Grid cols={{ base: 1, md: 3 }} gap="s">
             <Surface variant="outline" p="m">
@@ -60,7 +63,10 @@ export function FoundationPrimitivesSection() {
         </Container>
       </Card>
 
-      <Card title="Center and Box" description="Box is the flexible primitive; Center aligns its children.">
+      <Card
+        title="Center and Box"
+        description="Box is the flexible primitive; Center aligns its children."
+      >
         <Center minHeight={96} p="m">
           <Box p="m" radius="m" bg="surface">
             <Text weight="semiBold">Centered Box</Text>
@@ -68,7 +74,10 @@ export function FoundationPrimitivesSection() {
         </Center>
       </Card>
 
-      <Card title="Surface variants" description="Default, subtle, raised, and outline surfaces are re-exported by ZORA.">
+      <Card
+        title="Surface variants"
+        description="Default, subtle, raised, and outline surfaces are re-exported by ZORA."
+      >
         <Grid cols={{ base: 1, md: 4 }} gap="s">
           <Surface variant="default" p="m">
             <Text>Default</Text>
@@ -85,7 +94,10 @@ export function FoundationPrimitivesSection() {
         </Grid>
       </Card>
 
-      <Card title="Divider, Spacer, and Show" description="Small layout utilities keep examples readable.">
+      <Card
+        title="Divider, Spacer, and Show"
+        description="Small layout utilities keep examples readable."
+      >
         <Stack gap="s">
           <Text>First block</Text>
           <Divider />

--- a/examples/expo-showcase/app/sections/foundationPrimitives.tsx
+++ b/examples/expo-showcase/app/sections/foundationPrimitives.tsx
@@ -1,0 +1,106 @@
+import {
+  Badge,
+  Box,
+  Card,
+  Center,
+  Container,
+  Divider,
+  Grid,
+  Inline,
+  PageSection,
+  Show,
+  Spacer,
+  Stack,
+  Surface,
+  Text,
+} from '@ankhorage/zora';
+import React from 'react';
+
+export function FoundationPrimitivesSection() {
+  return (
+    <PageSection title="Foundation primitives">
+      <Card
+        title="Stack and Inline"
+        description="Use Stack for vertical rhythm and Inline for wrapped horizontal groups."
+      >
+        <Stack gap="m">
+          <Stack gap="s">
+            <Surface variant="subtle" p="m">
+              <Text weight="semiBold">Stack item</Text>
+            </Surface>
+            <Surface variant="subtle" p="m">
+              <Text weight="semiBold">Second stack item</Text>
+            </Surface>
+          </Stack>
+          <Inline gap="s">
+            <Badge tone="primary">Inline</Badge>
+            <Badge tone="success" emphasis="soft">
+              Wrapped
+            </Badge>
+            <Badge tone="warning" emphasis="soft">
+              Metadata
+            </Badge>
+          </Inline>
+        </Stack>
+      </Card>
+
+      <Card title="Grid and Container" description="Responsive containers and grids keep catalog surfaces aligned.">
+        <Container maxWidth={720} px="s">
+          <Grid cols={{ base: 1, md: 3 }} gap="s">
+            <Surface variant="outline" p="m">
+              <Text>Grid cell A</Text>
+            </Surface>
+            <Surface variant="outline" p="m">
+              <Text>Grid cell B</Text>
+            </Surface>
+            <Surface variant="outline" p="m">
+              <Text>Grid cell C</Text>
+            </Surface>
+          </Grid>
+        </Container>
+      </Card>
+
+      <Card title="Center and Box" description="Box is the flexible primitive; Center aligns its children.">
+        <Center minHeight={96} p="m">
+          <Box p="m" radius="m" bg="surface">
+            <Text weight="semiBold">Centered Box</Text>
+          </Box>
+        </Center>
+      </Card>
+
+      <Card title="Surface variants" description="Default, subtle, raised, and outline surfaces are re-exported by ZORA.">
+        <Grid cols={{ base: 1, md: 4 }} gap="s">
+          <Surface variant="default" p="m">
+            <Text>Default</Text>
+          </Surface>
+          <Surface variant="subtle" p="m">
+            <Text>Subtle</Text>
+          </Surface>
+          <Surface variant="raised" p="m">
+            <Text>Raised</Text>
+          </Surface>
+          <Surface variant="outline" p="m">
+            <Text>Outline</Text>
+          </Surface>
+        </Grid>
+      </Card>
+
+      <Card title="Divider, Spacer, and Show" description="Small layout utilities keep examples readable.">
+        <Stack gap="s">
+          <Text>First block</Text>
+          <Divider />
+          <Spacer size="s" />
+          <Text>Second block after a spacer</Text>
+          <Show
+            when={{ base: true, md: false }}
+            fallback={<Badge tone="neutral">Desktop fallback</Badge>}
+          >
+            <Badge tone="primary" emphasis="soft">
+              Visible on base breakpoint
+            </Badge>
+          </Show>
+        </Stack>
+      </Card>
+    </PageSection>
+  );
+}

--- a/examples/expo-showcase/app/sections/layoutsShowcase.tsx
+++ b/examples/expo-showcase/app/sections/layoutsShowcase.tsx
@@ -1,0 +1,82 @@
+import {
+  AuthLayout,
+  Badge,
+  Button,
+  Card,
+  PageSection,
+  SettingsLayout,
+  SidebarLayout,
+  Stack,
+  Surface,
+  Text,
+  TopbarLayout,
+} from '@ankhorage/zora';
+import React from 'react';
+
+export function LayoutsShowcaseSection() {
+  return (
+    <PageSection title="Layouts">
+      <Card title="AuthLayout" description="Centered auth surfaces with title, description, and footer.">
+        <AuthLayout
+          eyebrow="Secure area"
+          title="Welcome back"
+          description="AuthLayout keeps sign-in flows visually focused."
+          footer={<Text tone="muted">Need access? Contact an admin.</Text>}
+        >
+          <Button size="s">Continue</Button>
+        </AuthLayout>
+      </Card>
+
+      <Card title="SettingsLayout" description="Settings pages can pair navigation with focused content.">
+        <SettingsLayout
+          title="Workspace settings"
+          description="Compact showcase example."
+          sidebar={
+            <Stack gap="s">
+              <Badge tone="primary">General</Badge>
+              <Badge tone="neutral" emphasis="soft">
+                Members
+              </Badge>
+            </Stack>
+          }
+          actions={<Button size="s">Save</Button>}
+        >
+          <Surface variant="subtle" p="m">
+            <Text>Settings content area</Text>
+          </Surface>
+        </SettingsLayout>
+      </Card>
+
+      <Card title="SidebarLayout" description="Sidebar, content, and optional aside regions.">
+        <SidebarLayout
+          sidebar={
+            <Stack gap="s">
+              <Text weight="semiBold">Sidebar</Text>
+              <Badge tone="neutral">Navigation</Badge>
+            </Stack>
+          }
+          aside={<Text tone="muted">Aside</Text>}
+        >
+          <Surface variant="subtle" p="m">
+            <Text>Main content</Text>
+          </Surface>
+        </SidebarLayout>
+      </Card>
+
+      <Card title="TopbarLayout" description="Topbar plus optional sidebar for editor-style screens.">
+        <TopbarLayout
+          topbar={
+            <Surface variant="outline" p="s">
+              <Text weight="semiBold">Topbar</Text>
+            </Surface>
+          }
+          sidebar={<Badge tone="primary">Tools</Badge>}
+        >
+          <Surface variant="subtle" p="m">
+            <Text>Topbar content area</Text>
+          </Surface>
+        </TopbarLayout>
+      </Card>
+    </PageSection>
+  );
+}

--- a/examples/expo-showcase/app/sections/layoutsShowcase.tsx
+++ b/examples/expo-showcase/app/sections/layoutsShowcase.tsx
@@ -16,7 +16,10 @@ import React from 'react';
 export function LayoutsShowcaseSection() {
   return (
     <PageSection title="Layouts">
-      <Card title="AuthLayout" description="Centered auth surfaces with title, description, and footer.">
+      <Card
+        title="AuthLayout"
+        description="Centered auth surfaces with title, description, and footer."
+      >
         <AuthLayout
           eyebrow="Secure area"
           title="Welcome back"
@@ -27,7 +30,10 @@ export function LayoutsShowcaseSection() {
         </AuthLayout>
       </Card>
 
-      <Card title="SettingsLayout" description="Settings pages can pair navigation with focused content.">
+      <Card
+        title="SettingsLayout"
+        description="Settings pages can pair navigation with focused content."
+      >
         <SettingsLayout
           title="Workspace settings"
           description="Compact showcase example."
@@ -63,7 +69,10 @@ export function LayoutsShowcaseSection() {
         </SidebarLayout>
       </Card>
 
-      <Card title="TopbarLayout" description="Topbar plus optional sidebar for editor-style screens.">
+      <Card
+        title="TopbarLayout"
+        description="Topbar plus optional sidebar for editor-style screens."
+      >
         <TopbarLayout
           topbar={
             <Surface variant="outline" p="s">

--- a/examples/expo-showcase/app/sections/patternGaps.tsx
+++ b/examples/expo-showcase/app/sections/patternGaps.tsx
@@ -1,0 +1,138 @@
+import {
+  Badge,
+  Button,
+  Card,
+  ConfirmDialog,
+  IconButton,
+  Notice,
+  PageSection,
+  Panel,
+  ResponsivePanel,
+  SectionHeader,
+  SettingsRow,
+  Stack,
+  SwitchField,
+  Text,
+  TreeItem,
+} from '@ankhorage/zora';
+import React from 'react';
+
+export function PatternGapsSection() {
+  const [confirmOpen, setConfirmOpen] = React.useState(false);
+  const [panelOpen, setPanelOpen] = React.useState(true);
+  const [syncEnabled, setSyncEnabled] = React.useState(true);
+
+  return (
+    <PageSection title="Additional patterns">
+      <SectionHeader
+        title="Dialogs and panels"
+        description="Focused confirmation and contextual panel patterns."
+      />
+
+      <Card
+        title="ConfirmDialog"
+        description="Use confirm dialogs for destructive or important decisions."
+        actions={
+          <Button size="s" tone="danger" emphasis="soft" onPress={() => setConfirmOpen(true)}>
+            Open confirm
+          </Button>
+        }
+      >
+        <Text tone="muted" variant="bodySmall">
+          Opens a mock confirmation dialog without performing a real action.
+        </Text>
+      </Card>
+
+      <Panel
+        title="Panel"
+        description="Panels compose title, description, actions, footer, and content."
+        actions={<IconButton icon={{ name: 'settings-outline' }} label="Panel settings" size="s" />}
+        footer={<Badge tone="success">Ready</Badge>}
+      >
+        <Notice
+          tone="primary"
+          title="Panel content"
+          description="This is a compact panel example inside the pattern catalog."
+        />
+      </Panel>
+
+      <ResponsivePanel
+        title="ResponsivePanel"
+        description="Inline on desktop, drawer or modal in floating mode."
+        open={panelOpen}
+        onOpenChange={setPanelOpen}
+        actions={
+          <Button size="s" emphasis="soft" onPress={() => setPanelOpen(false)}>
+            Hide
+          </Button>
+        }
+      >
+        <Stack gap="s">
+          <Text>Inline responsive panel content.</Text>
+          <Button size="s" emphasis="soft" onPress={() => setPanelOpen(true)}>
+            Reopen
+          </Button>
+        </Stack>
+      </ResponsivePanel>
+      {panelOpen ? null : (
+        <Button size="s" emphasis="soft" onPress={() => setPanelOpen(true)}>
+          Show responsive panel
+        </Button>
+      )}
+
+      <SectionHeader
+        title="Settings rows"
+        description="SettingsRow works for static, pressable, and controlled settings content."
+      />
+      <Card title="SettingsRow" tone="subtle">
+        <Stack gap="s">
+          <SettingsRow
+            title="Account plan"
+            description="Static metadata row."
+            meta={<Badge tone="primary">Pro</Badge>}
+          />
+          <SettingsRow
+            title="Open billing"
+            description="Pressable row with a mock action."
+            onPress={() => undefined}
+            meta="⌘B"
+          />
+          <SettingsRow
+            title="Background sync"
+            description="Controlled settings row."
+            control={
+              <SwitchField
+                label="Background sync"
+                value={syncEnabled}
+                onValueChange={setSyncEnabled}
+              />
+            }
+          />
+        </Stack>
+      </Card>
+
+      <SectionHeader
+        title="TreeItem"
+        description="TreeItem is exported directly and can be shown without a full TreeView."
+      />
+      <Card title="Standalone TreeItem" tone="subtle">
+        <TreeItem
+          node={{ id: 'direct-tree-item', label: 'Direct TreeItem export', meta: 'tsx' }}
+          depth={0}
+          expandedIds={[]}
+          onToggleExpand={() => undefined}
+        />
+      </Card>
+
+      <ConfirmDialog
+        visible={confirmOpen}
+        title="Delete showcase item?"
+        description="This is a mock confirmation dialog for visual coverage."
+        confirmLabel="Delete"
+        confirmTone="danger"
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => setConfirmOpen(false)}
+      />
+    </PageSection>
+  );
+}

--- a/examples/expo-showcase/app/theme-composer.tsx
+++ b/examples/expo-showcase/app/theme-composer.tsx
@@ -1,4 +1,3 @@
-import { Stack } from '@ankhorage/surface';
 import {
   Badge,
   Button,
@@ -10,6 +9,7 @@ import {
   PageHeader,
   PageSection,
   Panel,
+  Stack,
   Tabs,
   Text,
   Textarea,

--- a/src/showcaseCoverage.test.ts
+++ b/src/showcaseCoverage.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'bun:test';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
 
 const SHOWCASE_ROOT = join(process.cwd(), 'examples', 'expo-showcase');
 

--- a/src/showcaseCoverage.test.ts
+++ b/src/showcaseCoverage.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SHOWCASE_ROOT = join(process.cwd(), 'examples', 'expo-showcase');
+
+const REQUIRED_SHOWCASE_COVERAGE = {
+  components: [
+    'Badge',
+    'Button',
+    'Card',
+    'Checkbox',
+    'CheckboxGroup',
+    'Drawer',
+    'Form',
+    'FormActions',
+    'FormError',
+    'FormField',
+    'Heading',
+    'Icon',
+    'IconButton',
+    'Input',
+    'Modal',
+    'Radio',
+    'RadioGroup',
+    'Select',
+    'Tabs',
+    'Text',
+    'Textarea',
+    'Toolbar',
+    'ToolbarAction',
+  ],
+  foundation: [
+    'Box',
+    'Center',
+    'Container',
+    'Divider',
+    'Grid',
+    'Inline',
+    'Show',
+    'Spacer',
+    'Stack',
+    'Surface',
+  ],
+  layouts: [
+    'AppShell',
+    'AuthLayout',
+    'Page',
+    'PageHeader',
+    'PageSection',
+    'SettingsLayout',
+    'SidebarLayout',
+    'TopbarLayout',
+  ],
+  patterns: [
+    'ForgotPasswordForm',
+    'OtpForm',
+    'SignInForm',
+    'SignUpForm',
+    'CollectionEditor',
+    'ConfirmDialog',
+    'DisclosureSection',
+    'EmptyState',
+    'InspectorField',
+    'Notice',
+    'Panel',
+    'ResponsivePanel',
+    'SectionHeader',
+    'SettingsRow',
+    'SwitchField',
+    'ThemeComposer',
+    'PaletteItem',
+    'TileGrid',
+    'TreeItem',
+    'TreeView',
+  ],
+} as const;
+
+function listFiles(root: string): string[] {
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const absolutePath = join(root, entry.name);
+    if (entry.isDirectory()) {
+      return listFiles(absolutePath);
+    }
+
+    return entry.isFile() && /\.[cm]?tsx?$/.test(entry.name) ? [absolutePath] : [];
+  });
+}
+
+function readShowcaseSource(): string {
+  return listFiles(SHOWCASE_ROOT)
+    .map((filePath) => readFileSync(filePath, 'utf8'))
+    .join('\n');
+}
+
+describe('expo showcase coverage policy', () => {
+  test('does not import Surface directly from the showcase app', () => {
+    for (const filePath of listFiles(SHOWCASE_ROOT)) {
+      const source = readFileSync(filePath, 'utf8');
+      expect(source).not.toContain("from '@ankhorage/surface'");
+      expect(source).not.toContain('from "@ankhorage/surface"');
+    }
+  });
+
+  test('documents public ZORA API coverage in the showcase source', () => {
+    const source = readShowcaseSource();
+    const requiredNames = Object.values(REQUIRED_SHOWCASE_COVERAGE).flat();
+
+    for (const requiredName of requiredNames) {
+      expect(source).toContain(requiredName);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #53.

Refreshes the Expo showcase as a broader living catalog for the public ZORA API.

- removes direct `@ankhorage/surface` imports from showcase files
- adds foundation primitive coverage for `Box`, `Center`, `Container`, `Divider`, `Grid`, `Inline`, `Show`, `Spacer`, `Stack`, and `Surface`
- adds missing component coverage for standalone `Checkbox`, standalone `Radio`, plain `Icon`, `Form`, `FormActions`, and `FormError`
- adds layout coverage for `AuthLayout`, `SettingsLayout`, `SidebarLayout`, and `TopbarLayout`
- adds missing pattern coverage for `ConfirmDialog`, `Panel`, `ResponsivePanel`, `SettingsRow`, and direct `TreeItem`
- keeps the existing tab count and splits new coverage into smaller section files
- adds a dependency-free showcase policy test that blocks direct Surface imports in `examples/expo-showcase` and records required public API coverage names

## Boundary note

The showcase now consumes app-facing primitives from `@ankhorage/zora`. Direct Surface imports remain a ZORA-internal concern only.

## Changeset

No changeset added because this is examples/showcase coverage plus a policy test only. It does not change the published runtime API.

## Verification

Not run locally from this environment. CI should run on the PR.