### PR TITLE
feat(app-bar): add Surface-backed AppBar

### DIFF
--- a/.changeset/add-app-bar.md
+++ b/.changeset/add-app-bar.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/zora": minor
+'@ankhorage/zora': minor
 ---
 
 Add a product-facing `AppBar` component backed by the Surface `AppBar` primitive.
@@ -7,4 +7,3 @@ Add a product-facing `AppBar` component backed by the Surface `AppBar` primitive
 The new component supports title/subtitle content, leading and trailing actions,
 an overflow trigger entrypoint, and generic prop-driven selection mode while
 keeping the existing `Toolbar` API unchanged.
-

--- a/.changeset/add-app-bar.md
+++ b/.changeset/add-app-bar.md
@@ -1,0 +1,10 @@
+---
+"@ankhorage/zora": minor
+---
+
+Add a product-facing `AppBar` component backed by the Surface `AppBar` primitive.
+
+The new component supports title/subtitle content, leading and trailing actions,
+an overflow trigger entrypoint, and generic prop-driven selection mode while
+keeping the existing `Toolbar` API unchanged.
+

--- a/README.md
+++ b/README.md
@@ -970,7 +970,9 @@ Selection mode is generic and prop-driven:
 ```tsx
 <AppBar
   appMode={{ type: 'selection', label: 'Selected', count: 3, onCancel: exitSelection }}
-  actions={<IconButton icon={{ name: 'trash-outline' }} label="Delete" tone="danger" onPress={del} />}
+  actions={
+    <IconButton icon={{ name: 'trash-outline' }} label="Delete" tone="danger" onPress={del} />
+  }
 />
 ```
 
@@ -979,16 +981,16 @@ Selection mode is generic and prop-driven:
 
 ZORA props:
 
-| Prop        | Type               | Default | Notes                                                                 |
-| ----------- | ------------------ | ------- | --------------------------------------------------------------------- |
-| `title`     | `React.ReactNode`  | -       | Primary title content.                                                |
-| `subtitle`  | `React.ReactNode`  | -       | Optional secondary line.                                              |
-| `leading`   | `React.ReactNode`  | -       | Optional leading content (e.g. back/menu button).                     |
-| `actions`   | `React.ReactNode`  | -       | Optional trailing actions content.                                    |
-| `overflow`  | `AppBarOverflowAction` | -   | Optional overflow trigger entrypoint (no built-in menu behavior).     |
-| `appMode`   | `AppBarMode`       | -       | Default or selection-mode rendering.                                  |
-| `safeAreaTop` | `boolean`        | `true`  | Adds top safe-area padding when `SafeAreaProvider` is present.        |
-| `divider`   | `boolean`          | `true`  | Whether to render a divider under the bar.                            |
+| Prop          | Type                   | Default | Notes                                                             |
+| ------------- | ---------------------- | ------- | ----------------------------------------------------------------- |
+| `title`       | `React.ReactNode`      | -       | Primary title content.                                            |
+| `subtitle`    | `React.ReactNode`      | -       | Optional secondary line.                                          |
+| `leading`     | `React.ReactNode`      | -       | Optional leading content (e.g. back/menu button).                 |
+| `actions`     | `React.ReactNode`      | -       | Optional trailing actions content.                                |
+| `overflow`    | `AppBarOverflowAction` | -       | Optional overflow trigger entrypoint (no built-in menu behavior). |
+| `appMode`     | `AppBarMode`           | -       | Default or selection-mode rendering.                              |
+| `safeAreaTop` | `boolean`              | `true`  | Adds top safe-area padding when `SafeAreaProvider` is present.    |
+| `divider`     | `boolean`              | `true`  | Whether to render a divider under the bar.                        |
 
 Inherited props:
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ Wrap your app in `ZoraProvider`, then import components from
 ```tsx
 import React from 'react';
 import {
+  AppBar,
   AppShell,
   Button,
   Card,
   Heading,
+  IconButton,
   Page,
   PageHeader,
   Text,
-  Toolbar,
-  ToolbarAction,
   ZoraProvider,
 } from '@ankhorage/zora';
 
@@ -47,9 +47,10 @@ export function App() {
     <ZoraProvider>
       <AppShell
         header={
-          <Toolbar>
-            <ToolbarAction icon={{ name: 'menu-outline' }} label="Menu" />
-          </Toolbar>
+          <AppBar
+            leading={<IconButton icon={{ name: 'menu-outline' }} label="Menu" onPress={() => {}} />}
+            title="Dashboard"
+          />
         }
       >
         <Page header={<PageHeader title="Dashboard" description="Ready to build." />}>
@@ -943,6 +944,55 @@ ZORA props:
 | `onValueChange` | `(value: string) => void`              | -             | Change handler.       |
 | `variant`       | `'underline' \| 'pill' \| 'segmented'` | `'underline'` | Visual style.         |
 | `size`          | `ZoraControlSize`                      | `'m'`         | Control size.         |
+
+</details>
+
+### `AppBar`
+
+Product-facing top app bar backed by the Surface `AppBar` primitive.
+
+Use it for screen-level chrome (title/subtitle + leading/trailing actions).
+The optional overflow entrypoint is trigger-only: consumers decide whether to
+open a menu, sheet, modal, or something else.
+
+```tsx
+<AppBar
+  title="Inbox"
+  subtitle="All conversations"
+  leading={<IconButton icon={{ name: 'menu-outline' }} label="Open menu" onPress={openMenu} />}
+  actions={<IconButton icon={{ name: 'search-outline' }} label="Search" onPress={openSearch} />}
+  overflow={{ onPress: openOverflow, label: 'More actions' }}
+/>
+```
+
+Selection mode is generic and prop-driven:
+
+```tsx
+<AppBar
+  appMode={{ type: 'selection', label: 'Selected', count: 3, onCancel: exitSelection }}
+  actions={<IconButton icon={{ name: 'trash-outline' }} label="Delete" tone="danger" onPress={del} />}
+/>
+```
+
+<details>
+<summary>Props</summary>
+
+ZORA props:
+
+| Prop        | Type               | Default | Notes                                                                 |
+| ----------- | ------------------ | ------- | --------------------------------------------------------------------- |
+| `title`     | `React.ReactNode`  | -       | Primary title content.                                                |
+| `subtitle`  | `React.ReactNode`  | -       | Optional secondary line.                                              |
+| `leading`   | `React.ReactNode`  | -       | Optional leading content (e.g. back/menu button).                     |
+| `actions`   | `React.ReactNode`  | -       | Optional trailing actions content.                                    |
+| `overflow`  | `AppBarOverflowAction` | -   | Optional overflow trigger entrypoint (no built-in menu behavior).     |
+| `appMode`   | `AppBarMode`       | -       | Default or selection-mode rendering.                                  |
+| `safeAreaTop` | `boolean`        | `true`  | Adds top safe-area padding when `SafeAreaProvider` is present.        |
+| `divider`   | `boolean`          | `true`  | Whether to render a divider under the bar.                            |
+
+Inherited props:
+
+None. ZORA composes Surface internally and exposes a product API.
 
 </details>
 

--- a/examples/expo-showcase/app/components.tsx
+++ b/examples/expo-showcase/app/components.tsx
@@ -1,4 +1,5 @@
 import {
+  AppBar,
   Avatar,
   AvatarGroup,
   Badge,
@@ -262,6 +263,59 @@ export function ComponentsPage() {
               <Chip>Static chip</Chip>
             </Stack>
           </Stack>
+        </PageSection>
+
+        <PageSection title="App bars">
+          <SectionHeader
+            title="Default"
+            description="Product-facing screen chrome built on the Surface AppBar primitive."
+          />
+          <AppBar
+            actions={
+              <>
+                <IconButton
+                  icon={{ name: 'search-outline' }}
+                  label="Search"
+                  onPress={() => undefined}
+                />
+              </>
+            }
+            leading={
+              <IconButton
+                icon={{ name: 'menu-outline' }}
+                label="Open menu"
+                onPress={() => undefined}
+              />
+            }
+            overflow={{ label: 'More actions', onPress: () => undefined }}
+            subtitle="All conversations"
+            title="Inbox"
+          />
+
+          <SectionHeader
+            title="Selection mode"
+            description="Generic selection-mode rendering stays prop-driven and reusable."
+          />
+          <AppBar
+            actions={
+              <>
+                <IconButton
+                  emphasis="ghost"
+                  icon={{ name: 'trash-outline' }}
+                  label="Delete"
+                  tone="danger"
+                  onPress={() => undefined}
+                />
+              </>
+            }
+            appMode={{
+              type: 'selection',
+              label: 'Selected',
+              count: 3,
+              onCancel: () => undefined,
+            }}
+            overflow={{ label: 'More selection actions', onPress: () => undefined }}
+          />
         </PageSection>
 
         <PageSection title="Toolbars">

--- a/src/components/app-bar/AppBar.tsx
+++ b/src/components/app-bar/AppBar.tsx
@@ -1,0 +1,133 @@
+import { AppBar as SurfaceAppBar } from '@ankhorage/surface';
+import React from 'react';
+
+import { Box, Inline, Stack } from '../../foundation';
+import { useZoraTheme } from '../../theme/useZoraTheme';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import { Heading } from '../heading';
+import { IconButton } from '../icon-button';
+import { Text } from '../text';
+import type { AppBarMode, AppBarOverflowAction, AppBarProps } from './types';
+
+const DEFAULT_CANCEL_ICON = { name: 'close-outline' };
+const DEFAULT_OVERFLOW_ICON = { name: 'ellipsis-vertical' };
+
+function resolveMode(mode: AppBarMode | undefined): AppBarMode {
+  return mode ?? { type: 'default' };
+}
+
+function resolveSelectionLabel({ count, label }: { count?: number; label: string }): string {
+  if (count === undefined) {
+    return label;
+  }
+
+  return `${label} (${count})`;
+}
+
+function resolveOverflowLabel(overflow: AppBarOverflowAction): string {
+  return overflow.label ?? 'More options';
+}
+
+function resolveCancelLabel(mode: Extract<AppBarMode, { type: 'selection' }>): string {
+  return mode.cancelLabel ?? 'Cancel selection';
+}
+
+function AppBarInner({
+  themeId: _themeId,
+  mode: _mode,
+  title,
+  subtitle,
+  leading,
+  actions,
+  overflow,
+  appMode,
+  children,
+  safeAreaTop = true,
+  divider = true,
+  testID,
+}: AppBarProps) {
+  const { theme } = useZoraTheme();
+  const resolvedMode = resolveMode(appMode);
+  const isSelectionMode = resolvedMode.type === 'selection';
+
+  const resolvedLeading =
+    leading ??
+    (isSelectionMode ? (
+      <IconButton
+        icon={resolvedMode.cancelIcon ?? DEFAULT_CANCEL_ICON}
+        label={resolveCancelLabel(resolvedMode)}
+        emphasis="ghost"
+        size="m"
+        tone="neutral"
+        onPress={resolvedMode.onCancel}
+      />
+    ) : undefined);
+
+  const overflowButton = overflow?.onPress ? (
+    <IconButton
+      disabled={overflow.disabled}
+      icon={overflow.icon ?? DEFAULT_OVERFLOW_ICON}
+      label={resolveOverflowLabel(overflow)}
+      emphasis="ghost"
+      size="m"
+      tone="neutral"
+      onPress={overflow.onPress}
+    />
+  ) : null;
+
+  const resolvedTrailing =
+    actions || overflowButton ? (
+      <Inline align="center" gap="s" wrap="nowrap">
+        {actions}
+        {overflowButton}
+      </Inline>
+    ) : undefined;
+
+  const resolvedCenter = (() => {
+    if (children !== undefined) {
+      return children;
+    }
+
+    if (isSelectionMode) {
+      return (
+        <Text numberOfLines={1} tone="default" variant="label" weight="semiBold">
+          {resolveSelectionLabel(resolvedMode)}
+        </Text>
+      );
+    }
+
+    if (title == null && subtitle == null) {
+      return null;
+    }
+
+    return (
+      <Stack gap="xs">
+        {title != null ? (
+          <Heading ellipsizeMode="tail" level={3} numberOfLines={1} size="h5">
+            {title}
+          </Heading>
+        ) : null}
+        {subtitle != null ? (
+          <Text ellipsizeMode="tail" numberOfLines={1} tone="muted" variant="bodySmall">
+            {subtitle}
+          </Text>
+        ) : null}
+      </Stack>
+    );
+  })();
+
+  return (
+    <SurfaceAppBar
+      bg={isSelectionMode ? theme.semantics.action.primary.softBg : undefined}
+      divider={divider}
+      leading={resolvedLeading}
+      safeAreaTop={safeAreaTop}
+      testID={testID}
+      trailing={resolvedTrailing}
+    >
+      {resolvedCenter ? <Box style={{ minWidth: 0 }}>{resolvedCenter}</Box> : null}
+    </SurfaceAppBar>
+  );
+}
+
+export const AppBar = withZoraThemeScope(AppBarInner);

--- a/src/components/app-bar/index.ts
+++ b/src/components/app-bar/index.ts
@@ -1,0 +1,2 @@
+export * from './AppBar';
+export * from './types';

--- a/src/components/app-bar/types.ts
+++ b/src/components/app-bar/types.ts
@@ -1,0 +1,36 @@
+import type { ButtonIconSpec } from '@ankhorage/surface';
+import type React from 'react';
+
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export type AppBarMode =
+  | {
+      type: 'default';
+    }
+  | {
+      type: 'selection';
+      label: string;
+      count?: number;
+      onCancel: () => void;
+      cancelLabel?: string;
+      cancelIcon?: ButtonIconSpec;
+    };
+
+export interface AppBarOverflowAction {
+  onPress: () => void;
+  label?: string;
+  icon?: ButtonIconSpec;
+  disabled?: boolean;
+}
+
+export interface AppBarProps extends ZoraBaseProps {
+  title?: React.ReactNode;
+  subtitle?: React.ReactNode;
+  leading?: React.ReactNode;
+  actions?: React.ReactNode;
+  overflow?: AppBarOverflowAction;
+  appMode?: AppBarMode;
+  children?: React.ReactNode;
+  safeAreaTop?: boolean;
+  divider?: boolean;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export type { AppBarMode, AppBarOverflowAction, AppBarProps } from './components/app-bar';
+export { AppBar } from './components/app-bar';
 export type { AvatarProps, AvatarShape, AvatarSize } from './components/avatar';
 export { Avatar, resolveAvatarInitials } from './components/avatar';
 export type { AvatarGroupItem, AvatarGroupProps } from './components/avatar-group';

--- a/src/showcaseCoverage.test.ts
+++ b/src/showcaseCoverage.test.ts
@@ -17,6 +17,7 @@ const IGNORED_DIRECTORY_NAMES = new Set([
 
 const REQUIRED_SHOWCASE_COVERAGE = {
   components: [
+    'AppBar',
     'Avatar',
     'AvatarGroup',
     'Badge',

--- a/src/theme/themeScopeStructure.test.ts
+++ b/src/theme/themeScopeStructure.test.ts
@@ -53,6 +53,7 @@ const scopeGuardDirs = [
 const scopeGuardFiles = scopeGuardDirs.flatMap(collectSourceFiles);
 
 const scopedComponentFiles = [
+  join(srcDir, 'components', 'app-bar', 'AppBar.tsx'),
   join(srcDir, 'components', 'badge', 'Badge.tsx'),
   join(srcDir, 'components', 'button', 'Button.tsx'),
   join(srcDir, 'components', 'card', 'Card.tsx'),
@@ -128,6 +129,7 @@ const scopedComponentFiles = [
 ] as const;
 
 const scopedPropTypeFiles = [
+  join(srcDir, 'components', 'app-bar', 'types.ts'),
   join(srcDir, 'components', 'badge', 'types.ts'),
   join(srcDir, 'components', 'button', 'types.ts'),
   join(srcDir, 'components', 'card', 'types.ts'),


### PR DESCRIPTION
## Summary

Adds a product-facing `AppBar` component to `@ankhorage/zora`, backed by the released `@ankhorage/surface` `AppBar` primitive.

The component provides mobile-first top app chrome with title/subtitle content, leading content, trailing actions, a trigger-only overflow entrypoint, and generic prop-driven selection-mode rendering.

Closes #126.

## Changes

- Add `src/components/app-bar/AppBar.tsx`.
- Add `src/components/app-bar/types.ts` with `AppBarProps`, `AppBarMode`, and overflow action types.
- Export `AppBar` and explicit public types from `src/index.ts`.
- Update the Surface dependency to `^1.3.0` for the released Surface `AppBar` primitive.
- Add AppBar showcase examples for default and selection modes.
- Add showcase coverage and theme scope structure coverage.
- Update README Quick Start and add AppBar docs while keeping `Toolbar` docs intact.
- Add a minor changeset for the new public ZORA component API.

## AppBar behavior

- `safeAreaTop` defaults to `true`.
- `divider` defaults to `true`.
- Composes `@ankhorage/surface` `AppBar`; it does not copy Surface layout code.
- Overflow is trigger-only; consumers decide whether to open a menu, sheet, modal, command palette, or another UI.
- Selection mode is generic and prop-driven via `appMode`.
- `Toolbar` / `ToolbarAction` remain supported and are not deprecated.
- Does not add Expo Router, React Navigation, Studio, or ankhorage4-specific behavior.

## Verification

- [x] CI passed
- [x] Bun Tests workflow passed