### PR TITLE
Add Hero pattern

### DIFF
--- a/.changeset/add-hero-pattern.md
+++ b/.changeset/add-hero-pattern.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/zora": patch
+---
+
+Add a first-class Hero pattern with structured content, actions, optional media, responsive layout behavior, metadata, and showcase coverage.

--- a/.changeset/add-hero-pattern.md
+++ b/.changeset/add-hero-pattern.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/zora": patch
+'@ankhorage/zora': patch
 ---
 
 Add a first-class Hero pattern with structured content, actions, optional media, responsive layout behavior, metadata, and showcase coverage.

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Metadata model overview:
 - `EmptyState`
 - `FilterBar`
 - `ForgotPasswordForm`
+- `Hero`
 - `ImagePreview`
 - `ImageUploadField`
 - `InspectorField`
@@ -1549,6 +1550,78 @@ Inherited props:
 
 Picks these Surface `FieldProps`: `children`, `disabled`, `errorText`,
 `invalid`, `readOnly`, `required`, and `testID`.
+
+</details>
+
+### `Hero`
+
+Landing-page and section hero pattern with structured title copy, actions,
+optional media, and responsive layout behavior.
+
+```tsx
+<Hero
+  eyebrow="New release"
+  title="Build product screens faster"
+  description="Use a responsive hero pattern with strong defaults for landing pages, dashboards, and app sections."
+  primaryAction={{ label: 'Get started', onPress: () => undefined }}
+  secondaryAction={{ label: 'View docs', onPress: () => undefined }}
+/>
+```
+
+With media:
+
+```tsx
+<Hero
+  eyebrow="ZORA Pattern"
+  title="Compose responsive product introductions"
+  description="Hero combines ZORA typography, actions, layout, and card surfaces into one app-facing pattern."
+  layout="split"
+  primaryAction={{ label: 'Start building', onPress: () => undefined }}
+  secondaryAction={{ label: 'Browse patterns', onPress: () => undefined }}
+  media={
+    <Card title="Theme-aware by default" tone="outline">
+      <Text tone="muted">
+        Use the media slot for previews, screenshots, metrics, or illustration cards.
+      </Text>
+    </Card>
+  }
+/>
+```
+
+<details>
+<summary>Props</summary>
+
+ZORA props:
+
+| Prop              | Type              | Default    | Notes                                                     |
+| ----------------- | ----------------- | ---------- | --------------------------------------------------------- |
+| `title`           | `React.ReactNode` | -          | Required main hero title.                                 |
+| `description`     | `React.ReactNode` | -          | Supporting copy below the title.                          |
+| `eyebrow`         | `React.ReactNode` | -          | Small label above the title.                              |
+| `primaryAction`   | `HeroAction`      | -          | Primary CTA rendered as a ZORA `Button`.                  |
+| `secondaryAction` | `HeroAction`      | -          | Secondary CTA rendered as a softer ZORA `Button`.         |
+| `media`           | `React.ReactNode` | -          | Optional media slot rendered beside or above the content. |
+| `footer`          | `React.ReactNode` | -          | Optional supporting footer content below the actions.     |
+| `align`           | `HeroAlign`       | `'start'`  | Content alignment: `'start'` or `'center'`.               |
+| `layout`          | `HeroLayout`      | `'split'`  | Layout strategy: `'stack'`, `'split'`, or `'mediaFirst'`. |
+| `tone`            | `HeroTone`        | `'subtle'` | Card tone: `'default'`, `'subtle'`, or `'outline'`.       |
+| `compact`         | `boolean`         | `false`    | Uses tighter spacing and a smaller desktop title size.    |
+| `testID`          | `string`          | -          | Test id forwarded to the underlying card surface.         |
+
+`HeroAction`:
+
+| Prop       | Type              | Default                   | Notes                              |
+| ---------- | ----------------- | ------------------------- | ---------------------------------- |
+| `label`    | `React.ReactNode` | -                         | Button label/content.              |
+| `onPress`  | `() => void`      | -                         | Press handler.                     |
+| `tone`     | `ZoraTone`        | primary / neutral by role | Optional button tone override.     |
+| `emphasis` | `ZoraEmphasis`    | solid / soft by role      | Optional button emphasis override. |
+| `disabled` | `boolean`         | `false`                   | Disables the rendered action.      |
+
+Inherited props:
+
+No inherited props. `HeroProps` is declared directly by ZORA to keep the
+pattern structured, theme-aware, and template-safe.
 
 </details>
 

--- a/examples/expo-showcase/app/home.tsx
+++ b/examples/expo-showcase/app/home.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Card, Page, PageHeader, PageSection } from '@ankhorage/zora';
+import { Badge, Button, Card, Hero, Page, PageSection, Text } from '@ankhorage/zora';
 import React from 'react';
 import { ScrollView } from 'react-native';
 
@@ -13,10 +13,20 @@ export function HomePage({ onNavigate }: HomePageProps) {
     <ScrollView>
       <Page
         header={
-          <PageHeader
+          <Hero
             eyebrow="ZORA Showcase"
             title="Build polished Expo and React Native Web interfaces"
             description="Explore ZORA components, scenario-based patterns, and live theme recipes in one small showcase app."
+            primaryAction={{ label: 'View patterns', onPress: () => onNavigate('patterns') }}
+            secondaryAction={{ label: 'Browse components', onPress: () => onNavigate('components') }}
+            media={
+              <Card title="Theme-aware by default" tone="outline">
+                <Text tone="muted">
+                  Hero composes ZORA typography, actions, layout, and card surfaces into one
+                  responsive pattern.
+                </Text>
+              </Card>
+            }
           />
         }
       >

--- a/examples/expo-showcase/app/home.tsx
+++ b/examples/expo-showcase/app/home.tsx
@@ -18,7 +18,10 @@ export function HomePage({ onNavigate }: HomePageProps) {
             title="Build polished Expo and React Native Web interfaces"
             description="Explore ZORA components, scenario-based patterns, and live theme recipes in one small showcase app."
             primaryAction={{ label: 'View patterns', onPress: () => onNavigate('patterns') }}
-            secondaryAction={{ label: 'Browse components', onPress: () => onNavigate('components') }}
+            secondaryAction={{
+              label: 'Browse components',
+              onPress: () => onNavigate('components'),
+            }}
             media={
               <Card title="Theme-aware by default" tone="outline">
                 <Text tone="muted">

--- a/src/components/form/index.ts
+++ b/src/components/form/index.ts
@@ -11,7 +11,6 @@ export type {
   FormFieldInputType,
   FormFieldProps,
   FormFieldValue,
-  FormFieldWrapperProps,
   FormProps,
   FormValidationErrors,
   FormValidationResult,

--- a/src/components/form/types.ts
+++ b/src/components/form/types.ts
@@ -37,7 +37,7 @@ export interface FormFieldConfig<TName extends string = string> {
   testID?: string;
 }
 
-export interface FormFieldWrapperProps
+interface FormFieldWrapperProps
   extends
     ZoraBaseProps,
     Pick<

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,6 @@ export type {
   FormFieldInputType,
   FormFieldProps,
   FormFieldValue,
-  FormFieldWrapperProps,
   FormProps,
   FormValidationErrors,
   FormValidationResult,
@@ -177,6 +176,8 @@ export type { EmptyStateAction, EmptyStateProps } from './patterns/empty-state';
 export { EmptyState } from './patterns/empty-state';
 export type { FilterBarProps } from './patterns/filter-bar';
 export { FilterBar } from './patterns/filter-bar';
+export type { HeroAction, HeroAlign, HeroLayout, HeroProps, HeroTone } from './patterns/hero';
+export { Hero } from './patterns/hero';
 export type {
   ImagePreviewProps,
   ZoraImageAsset,

--- a/src/metadata/componentMeta.test.ts
+++ b/src/metadata/componentMeta.test.ts
@@ -134,6 +134,7 @@ describe('ZORA_COMPONENT_META invariants', () => {
       'SectionHeader',
       'SettingsRow',
       'EmptyState',
+      'Hero',
       'Button',
       'Input',
       'Textarea',

--- a/src/metadata/componentMeta.ts
+++ b/src/metadata/componentMeta.ts
@@ -48,6 +48,7 @@ import { confirmDialogMeta } from '../patterns/confirm-dialog/meta';
 import { disclosureSectionMeta } from '../patterns/disclosure-section/meta';
 import { emptyStateMeta } from '../patterns/empty-state/meta';
 import { filterBarMeta } from '../patterns/filter-bar/meta';
+import { heroMeta } from '../patterns/hero/meta';
 import { imagePreviewMeta } from '../patterns/image-preview/meta';
 import { imageUploadFieldMeta } from '../patterns/image-upload-field/meta';
 import { inspectorFieldMeta } from '../patterns/inspector-field/meta';
@@ -122,6 +123,7 @@ export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   DisclosureSection: disclosureSectionMeta,
   EmptyState: emptyStateMeta,
   FilterBar: filterBarMeta,
+  Hero: heroMeta,
   ImagePreview: imagePreviewMeta,
   ImageUploadField: imageUploadFieldMeta,
   InspectorField: inspectorFieldMeta,

--- a/src/patterns/hero/Hero.tsx
+++ b/src/patterns/hero/Hero.tsx
@@ -25,8 +25,10 @@ function HeroInner({
   testID,
 }: HeroProps) {
   const hasActions = primaryAction !== undefined || secondaryAction !== undefined;
-  const direction = resolveDirection(layout, media !== undefined);
+  const hasMedia = media !== undefined;
+  const direction = resolveDirection(layout, hasMedia);
   const contentAlign = resolveContentAlign(align);
+  const textAlign = align === 'center' ? 'center' : undefined;
   const mediaFirst = layout === 'mediaFirst';
 
   const content = (
@@ -34,23 +36,19 @@ function HeroInner({
       <Stack align={contentAlign} gap={compact ? 's' : 'm'}>
         <Stack align={contentAlign} gap="xs">
           {eyebrow !== undefined ? (
-            <Text align={align === 'center' ? 'center' : undefined} tone="primary" variant="eyebrow">
+            <Text align={textAlign} tone="primary" variant="eyebrow">
               {eyebrow}
             </Text>
           ) : null}
           <Heading
-            align={align === 'center' ? 'center' : undefined}
+            align={textAlign}
             level={1}
             size={{ base: 'h2', md: compact ? 'h2' : 'display' }}
           >
             {title}
           </Heading>
           {description !== undefined ? (
-            <Text
-              align={align === 'center' ? 'center' : undefined}
-              tone="muted"
-              variant={{ base: 'body', md: compact ? 'body' : 'lead' }}
-            >
+            <Text tone="muted" align={textAlign} variant={{ base: 'body', md: compact ? 'body' : 'lead' }}>
               {description}
             </Text>
           ) : null}
@@ -73,13 +71,13 @@ function HeroInner({
     </Box>
   );
 
-  const mediaSlot = media !== undefined ? <Box flex={1}>{media}</Box> : null;
-  const children = mediaFirst ? [mediaSlot, content] : [content, mediaSlot];
+  const mediaSlot = hasMedia ? <Box flex={1}>{media}</Box> : null;
 
   return (
     <Card compact={compact} testID={testID} tone={tone}>
       <Stack align="center" direction={direction} gap={compact ? 'm' : 'l'}>
-        {children}
+        {mediaFirst ? mediaSlot : content}
+        {mediaFirst ? content : mediaSlot}
       </Stack>
     </Card>
   );

--- a/src/patterns/hero/Hero.tsx
+++ b/src/patterns/hero/Hero.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+
+import { Button } from '../../components/button';
+import { Card } from '../../components/card';
+import { Heading } from '../../components/heading';
+import { Text } from '../../components/text';
+import { Box, Stack } from '../../foundation';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import type { HeroAction, HeroAlign, HeroLayout, HeroProps } from './types';
+
+function HeroInner({
+  themeId: _themeId,
+  mode: _mode,
+  title,
+  description,
+  eyebrow,
+  primaryAction,
+  secondaryAction,
+  media,
+  footer,
+  align = 'start',
+  layout = 'split',
+  tone = 'subtle',
+  compact = false,
+  testID,
+}: HeroProps) {
+  const hasActions = primaryAction !== undefined || secondaryAction !== undefined;
+  const direction = resolveDirection(layout, media !== undefined);
+  const contentAlign = resolveContentAlign(align);
+  const mediaFirst = layout === 'mediaFirst';
+
+  const content = (
+    <Box flex={1}>
+      <Stack align={contentAlign} gap={compact ? 's' : 'm'}>
+        <Stack align={contentAlign} gap="xs">
+          {eyebrow !== undefined ? (
+            <Text align={align === 'center' ? 'center' : undefined} tone="primary" variant="eyebrow">
+              {eyebrow}
+            </Text>
+          ) : null}
+          <Heading
+            align={align === 'center' ? 'center' : undefined}
+            level={1}
+            size={{ base: 'h2', md: compact ? 'h2' : 'display' }}
+          >
+            {title}
+          </Heading>
+          {description !== undefined ? (
+            <Text
+              align={align === 'center' ? 'center' : undefined}
+              tone="muted"
+              variant={{ base: 'body', md: compact ? 'body' : 'lead' }}
+            >
+              {description}
+            </Text>
+          ) : null}
+        </Stack>
+
+        {hasActions ? (
+          <Stack
+            align={contentAlign}
+            direction={{ base: 'column', md: 'row' }}
+            gap="s"
+            justify={align === 'center' ? 'center' : 'flex-start'}
+          >
+            {primaryAction !== undefined ? renderAction(primaryAction, 'primary') : null}
+            {secondaryAction !== undefined ? renderAction(secondaryAction, 'secondary') : null}
+          </Stack>
+        ) : null}
+
+        {footer}
+      </Stack>
+    </Box>
+  );
+
+  const mediaSlot = media !== undefined ? <Box flex={1}>{media}</Box> : null;
+  const children = mediaFirst ? [mediaSlot, content] : [content, mediaSlot];
+
+  return (
+    <Card compact={compact} testID={testID} tone={tone}>
+      <Stack align="center" direction={direction} gap={compact ? 'm' : 'l'}>
+        {children}
+      </Stack>
+    </Card>
+  );
+}
+
+function renderAction(action: HeroAction, role: 'primary' | 'secondary') {
+  return (
+    <Button
+      disabled={action.disabled}
+      emphasis={action.emphasis ?? (role === 'primary' ? 'solid' : 'soft')}
+      onPress={action.onPress}
+      tone={action.tone ?? (role === 'primary' ? 'primary' : 'neutral')}
+    >
+      {action.label}
+    </Button>
+  );
+}
+
+function resolveContentAlign(align: HeroAlign) {
+  return align === 'center' ? 'center' : 'flex-start';
+}
+
+function resolveDirection(layout: HeroLayout, hasMedia: boolean) {
+  if (!hasMedia || layout === 'stack') return 'column' as const;
+  return { base: 'column', md: 'row' } as const;
+}
+
+export const Hero = withZoraThemeScope(HeroInner);

--- a/src/patterns/hero/Hero.tsx
+++ b/src/patterns/hero/Hero.tsx
@@ -48,7 +48,11 @@ function HeroInner({
             {title}
           </Heading>
           {description !== undefined ? (
-            <Text tone="muted" align={textAlign} variant={{ base: 'body', md: compact ? 'body' : 'lead' }}>
+            <Text
+              tone="muted"
+              align={textAlign}
+              variant={{ base: 'body', md: compact ? 'body' : 'lead' }}
+            >
               {description}
             </Text>
           ) : null}

--- a/src/patterns/hero/index.ts
+++ b/src/patterns/hero/index.ts
@@ -1,0 +1,2 @@
+export { Hero } from './Hero';
+export type { HeroAction, HeroAlign, HeroLayout, HeroProps, HeroTone } from './types';

--- a/src/patterns/hero/meta.ts
+++ b/src/patterns/hero/meta.ts
@@ -1,0 +1,95 @@
+import type { ZoraComponentMeta } from '../../metadata';
+
+export const heroMeta = {
+  name: 'Hero',
+  category: 'pattern',
+  description: 'Landing-page and section hero with title copy, actions, and optional media.',
+  directManifestNode: true,
+  allowedChildren: [],
+  blueprint: {
+    label: 'Hero',
+    icon: { name: 'sparkles-outline' },
+    defaultProps: {
+      eyebrow: 'New release',
+      title: 'Build product screens faster',
+      description: 'Use a responsive hero pattern with strong defaults and structured actions.',
+      align: 'start',
+      layout: 'split',
+      tone: 'subtle',
+    },
+  },
+  i18n: {
+    fields: [
+      { keyProp: 'eyebrowI18nKey', defaultTextProp: 'eyebrow' },
+      { keyProp: 'titleI18nKey', defaultTextProp: 'title' },
+      { keyProp: 'descriptionI18nKey', defaultTextProp: 'description' },
+    ],
+  },
+  slots: {
+    media: {
+      label: 'Media',
+      allowedChildren: ['Image', 'Card', 'MetricCard', 'MediaCard'],
+    },
+    footer: {
+      label: 'Footer',
+      allowedChildren: ['Badge', 'Text', 'AvatarGroup'],
+    },
+  },
+  props: {
+    eyebrow: {
+      type: 'string',
+      category: 'Content',
+      label: 'Eyebrow',
+      default: 'New release',
+    },
+    title: {
+      type: 'string',
+      category: 'Content',
+      label: 'Title',
+      default: 'Build product screens faster',
+    },
+    description: {
+      type: 'string',
+      category: 'Content',
+      label: 'Description',
+      default: 'Use a responsive hero pattern with strong defaults and structured actions.',
+    },
+    align: {
+      type: 'enum',
+      category: 'Layout',
+      label: 'Alignment',
+      enum: ['start', 'center'],
+      default: 'start',
+    },
+    layout: {
+      type: 'enum',
+      category: 'Layout',
+      label: 'Layout',
+      enum: ['stack', 'split', 'mediaFirst'],
+      default: 'split',
+    },
+    tone: {
+      type: 'enum',
+      category: 'Appearance',
+      label: 'Tone',
+      enum: ['default', 'subtle', 'outline'],
+      default: 'subtle',
+    },
+    compact: {
+      type: 'boolean',
+      category: 'Layout',
+      label: 'Compact',
+      default: false,
+    },
+    primaryAction: {
+      type: 'action',
+      category: 'Actions',
+      label: 'Primary action',
+    },
+    secondaryAction: {
+      type: 'action',
+      category: 'Actions',
+      label: 'Secondary action',
+    },
+  },
+} as const satisfies ZoraComponentMeta;

--- a/src/patterns/hero/types.ts
+++ b/src/patterns/hero/types.ts
@@ -1,0 +1,30 @@
+import type React from 'react';
+
+import type { ZoraEmphasis, ZoraTone } from '../../internal/recipes';
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export type HeroAlign = 'start' | 'center';
+export type HeroLayout = 'stack' | 'split' | 'mediaFirst';
+export type HeroTone = 'default' | 'subtle' | 'outline';
+
+export interface HeroAction {
+  label: React.ReactNode;
+  onPress: () => void;
+  tone?: ZoraTone;
+  emphasis?: ZoraEmphasis;
+  disabled?: boolean;
+}
+
+export interface HeroProps extends ZoraBaseProps {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  eyebrow?: React.ReactNode;
+  primaryAction?: HeroAction;
+  secondaryAction?: HeroAction;
+  media?: React.ReactNode;
+  footer?: React.ReactNode;
+  align?: HeroAlign;
+  layout?: HeroLayout;
+  tone?: HeroTone;
+  compact?: boolean;
+}


### PR DESCRIPTION
Closes #127.

This adds a first-class ZORA Hero pattern.

Changes:

- adds `src/patterns/hero/` with typed `Hero` props and action model
- implements responsive `stack`, `split`, and `mediaFirst` layouts
- supports eyebrow, title, description, primary/secondary actions, optional media, footer, alignment, tone, and compact mode
- exports `Hero` and Hero types from the package entrypoint
- registers `Hero` in `ZORA_COMPONENT_META`
- updates metadata invariant tests for the new direct leaf pattern
- adds a generic Hero example to `examples/expo-showcase/app/home.tsx`
- adds a patch changeset

Out of scope, per issue:

- no `@ankhorage/surface` changes
- no ankhorage4 changes
- no templates changes

Verification target:

```bash
bun run build
bun run lint:fix
bun run test
bun run knip
```