### PR TITLE
feat: add PostCard pattern

### DIFF
--- a/.changeset/post-card-pattern.md
+++ b/.changeset/post-card-pattern.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Add a reusable PostCard pattern with showcase coverage.

--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ Metadata model overview:
 - `OtpForm`
 - `PaletteItem`
 - `Panel`
+- `PostCard`
 - `ResponsivePanel`
 - `SectionHeader`
 - `SelectableItem`
@@ -1761,6 +1762,148 @@ ZORA props:
 Inherited props:
 
 No inherited props. `PanelProps` is declared directly by ZORA.
+
+</details>
+
+### `PostCard`
+
+Reusable social/content post surface with author identity, optional media,
+interaction actions, and lightweight comment previews.
+
+`PostCard` owns the anatomy of one post. It does not own feed rendering,
+virtualization, pagination, pull-to-refresh, search/filter state, data fetching,
+or realtime behavior. Compose multiple posts with `Stack` for short/static
+groups, or use an app-owned `FlatList` for long dynamic feeds.
+
+```tsx
+import { IconButton, PostCard, Stack } from '@ankhorage/zora';
+
+export function PostsPreview() {
+  return (
+    <Stack gap="m">
+      <PostCard
+        author={{
+          name: 'Ada Lovelace',
+          subtitle: '@ada · 2h',
+          avatar: { name: 'Ada Lovelace', tone: 'primary' },
+        }}
+        headerAction={
+          <IconButton icon={{ name: 'ellipsis-horizontal-outline' }} label="More post options" />
+        }
+        text="Working on a reusable social pattern for ZORA."
+        actions={[
+          { id: 'like', label: 'Like', icon: { name: 'heart-outline' }, count: 24 },
+          {
+            id: 'comment',
+            label: 'Comment',
+            icon: { name: 'chatbubble-outline' },
+            count: 5,
+          },
+          { id: 'share', label: 'Share', icon: { name: 'share-outline' } },
+        ]}
+        comments={[
+          {
+            id: 'comment-1',
+            author: {
+              name: 'Grace Hopper',
+              subtitle: '1h',
+              avatar: { name: 'Grace Hopper', tone: 'success' },
+            },
+            text: 'The card/list boundary feels right.',
+          },
+        ]}
+      />
+
+      <PostCard
+        compact
+        tone="subtle"
+        author={{
+          name: 'Build system',
+          subtitle: 'Today · release notes',
+          avatar: { initials: 'CI', label: 'Build system', tone: 'neutral' },
+        }}
+        text="Compact density works well for notification-style posts."
+      />
+    </Stack>
+  );
+}
+```
+
+<details>
+<summary>Props</summary>
+
+ZORA props:
+
+| Prop           | Type                               | Default     | Notes                                                              |
+| -------------- | ---------------------------------- | ----------- | ------------------------------------------------------------------ |
+| `author`       | `PostAuthor`                       | -           | Required author identity with name, optional subtitle, and avatar. |
+| `text`         | `React.ReactNode`                  | -           | Main post copy.                                                    |
+| `children`     | `React.ReactNode`                  | -           | Optional custom body content rendered after `text`.                |
+| `media`        | `PostCardMedia \| PostCardMedia[]` | -           | Optional source-backed media or custom media slot.                 |
+| `actions`      | `PostAction[]`                     | `[]`        | Optional interaction row actions such as like/comment/share.       |
+| `comments`     | `PostCommentPreview[]`             | `[]`        | Optional lightweight comment preview rows.                         |
+| `headerAction` | `React.ReactNode`                  | -           | Optional trailing header action; disables card-level `onPress`.    |
+| `footer`       | `React.ReactNode`                  | -           | Optional footer content below actions/comments.                    |
+| `tone`         | `ZoraCardTone`                     | `'default'` | Passed to the underlying `Card`.                                   |
+| `compact`      | `boolean`                          | `false`     | Uses tighter spacing and smaller avatar defaults.                  |
+| `onPress`      | `() => void`                       | -           | Makes the card pressable when no `headerAction` is present.        |
+| `testID`       | `string`                           | -           | Forwarded to the underlying card.                                  |
+
+`PostAuthor`:
+
+| Prop       | Type               | Notes                                     |
+| ---------- | ------------------ | ----------------------------------------- |
+| `name`     | `React.ReactNode`  | Display name.                             |
+| `subtitle` | `React.ReactNode`  | Optional handle, timestamp, or meta text. |
+| `avatar`   | `PostAuthorAvatar` | Optional avatar configuration.            |
+
+`PostAuthorAvatar`:
+
+| Prop       | Type                  | Notes                                      |
+| ---------- | --------------------- | ------------------------------------------ |
+| `source`   | `ImageSourcePropType` | Optional avatar image source.              |
+| `name`     | `string`              | Used for fallback initials when available. |
+| `initials` | `string`              | Explicit fallback initials.                |
+| `label`    | `string`              | Accessibility label.                       |
+| `size`     | `AvatarSize`          | Optional avatar size override.             |
+| `shape`    | `AvatarShape`         | Optional avatar shape override.            |
+| `tone`     | `ZoraTone`            | Optional fallback tone.                    |
+
+`PostCardMedia`:
+
+| Prop          | Type                  | Notes                                                |
+| ------------- | --------------------- | ---------------------------------------------------- |
+| `source`      | `ImageSourcePropType` | Source-backed media. Requires `label`.               |
+| `label`       | `string`              | Accessibility label for source-backed media.         |
+| `aspectRatio` | `number`              | Optional aspect ratio. Defaults to `16 / 9`.         |
+| `children`    | `React.ReactNode`     | Custom media slot, mutually exclusive with `source`. |
+
+`PostAction`:
+
+| Prop       | Type              | Notes                                    |
+| ---------- | ----------------- | ---------------------------------------- |
+| `id`       | `string`          | Stable action key.                       |
+| `label`    | `string`          | Action label.                            |
+| `icon`     | `ButtonIconSpec`  | Optional leading icon.                   |
+| `count`    | `React.ReactNode` | Optional count rendered after the label. |
+| `selected` | `boolean`         | Uses primary/soft action styling.        |
+| `disabled` | `boolean`         | Disables the action.                     |
+| `onPress`  | `() => void`      | Optional press handler.                  |
+
+`PostCommentPreview`:
+
+| Prop     | Type              | Notes                                   |
+| -------- | ----------------- | --------------------------------------- |
+| `id`     | `string`          | Stable comment key.                     |
+| `author` | `PostAuthor`      | Optional comment author.                |
+| `text`   | `React.ReactNode` | Comment preview text.                   |
+| `meta`   | `React.ReactNode` | Optional timestamp or comment metadata. |
+| `action` | `React.ReactNode` | Optional custom comment action.         |
+
+Inherited props:
+
+No raw style escape hatch is exposed by `PostCard`. It uses the underlying ZORA
+`Card`, `Avatar`, `Text`, `Button`, and layout primitives internally.
 
 </details>
 

--- a/examples/expo-showcase/App.tsx
+++ b/examples/expo-showcase/App.tsx
@@ -15,9 +15,10 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ComponentsPage } from './app/components';
 import { HomePage } from './app/home';
 import { PatternsPage } from './app/patterns';
+import { PostsPage } from './app/posts';
 import { ThemeComposerPage } from './app/theme-composer';
 
-type ShowcaseTab = 'home' | 'components' | 'patterns' | 'theme';
+type ShowcaseTab = 'home' | 'components' | 'patterns' | 'posts' | 'theme';
 type ColorMode = ZoraThemeMode;
 
 const initialShowcaseTheme: ZoraTheme = {
@@ -47,6 +48,8 @@ function AppWrapper() {
         return <ComponentsPage />;
       case 'patterns':
         return <PatternsPage />;
+      case 'posts':
+        return <PostsPage />;
       case 'theme':
         return (
           <ThemeComposerPage
@@ -78,6 +81,7 @@ function AppWrapper() {
                   { value: 'home', label: 'Home' },
                   { value: 'components', label: 'Components' },
                   { value: 'patterns', label: 'Patterns' },
+                  { value: 'posts', label: 'Posts' },
                   { value: 'theme', label: 'Theme' },
                 ]}
               />

--- a/examples/expo-showcase/app/posts.tsx
+++ b/examples/expo-showcase/app/posts.tsx
@@ -1,0 +1,106 @@
+import { Badge, IconButton, Page, PageHeader, PageSection, PostCard, Stack, Text } from '@ankhorage/zora';
+import React from 'react';
+import { ScrollView } from 'react-native';
+
+import iconPng from '../assets/icon.png';
+
+const noop = () => undefined;
+
+export function PostsPage() {
+  return (
+    <ScrollView>
+      <Page
+        header={
+          <PageHeader
+            eyebrow="PostCard pattern"
+            title="Posts"
+            description="Reusable post cards composed in a plain Stack. Feed, Collection, and FlatList wrappers are intentionally out of scope for this example."
+          />
+        }
+      >
+        <PageSection
+          title="Stacked posts"
+          description="Use Stack for short/static groups. App-owned FlatList or a future Collection can render the same PostCard for long feeds."
+        >
+          <Stack gap="m">
+            <PostCard
+              author={{
+                name: 'Ada Lovelace',
+                subtitle: '@ada · 2h',
+                avatar: { name: 'Ada Lovelace', tone: 'primary' },
+              }}
+              headerAction={<IconButton icon={{ name: 'ellipsis-horizontal-outline' }} label="More post options" />}
+              text="Working on a reusable social pattern for ZORA. The card owns the post anatomy; the surrounding screen owns list behavior."
+              media={{ source: iconPng, label: 'ZORA showcase icon', aspectRatio: 16 / 9 }}
+              actions={[
+                { id: 'like', label: 'Like', icon: { name: 'heart-outline' }, count: 24, onPress: noop },
+                {
+                  id: 'comment',
+                  label: 'Comment',
+                  icon: { name: 'chatbubble-outline' },
+                  count: 5,
+                  onPress: noop,
+                },
+                { id: 'share', label: 'Share', icon: { name: 'share-outline' }, onPress: noop },
+              ]}
+              comments={[
+                {
+                  id: 'comment-1',
+                  author: {
+                    name: 'Grace Hopper',
+                    subtitle: '1h',
+                    avatar: { name: 'Grace Hopper', tone: 'success' },
+                  },
+                  text: 'The boundary between card anatomy and feed rendering feels right.',
+                },
+              ]}
+            />
+
+            <PostCard
+              compact
+              tone="subtle"
+              author={{
+                name: 'Build system',
+                subtitle: 'Today · release notes',
+                avatar: { initials: 'CI', label: 'Build system', tone: 'neutral' },
+              }}
+              text="PostCard also supports compact density for system updates and notification-style content."
+              actions={[
+                { id: 'ack', label: 'Acknowledge', icon: { name: 'checkmark-outline' }, onPress: noop },
+              ]}
+              footer={
+                <Text tone="subtle" variant="caption">
+                  Rendered as a standalone card inside Stack.
+                </Text>
+              }
+            />
+
+            <PostCard
+              author={{
+                name: 'Maya Chen',
+                subtitle: 'Product design · Yesterday',
+                avatar: { name: 'Maya Chen', tone: 'warning' },
+              }}
+              text="Custom media slots stay possible without making PostCard own uploads, storage, or provider logic."
+              media={{
+                label: 'Custom media placeholder',
+                children: (
+                  <Stack gap="s">
+                    <Badge tone="primary">Custom media slot</Badge>
+                    <Text tone="muted" variant="bodySmall">
+                      Consumers can render any ZORA-safe media preview here.
+                    </Text>
+                  </Stack>
+                ),
+              }}
+              actions={[
+                { id: 'like', label: 'Like', icon: { name: 'heart-outline' }, onPress: noop },
+                { id: 'comment', label: 'Comment', icon: { name: 'chatbubble-outline' }, onPress: noop },
+              ]}
+            />
+          </Stack>
+        </PageSection>
+      </Page>
+    </ScrollView>
+  );
+}

--- a/examples/expo-showcase/app/posts.tsx
+++ b/examples/expo-showcase/app/posts.tsx
@@ -1,4 +1,13 @@
-import { Badge, IconButton, Page, PageHeader, PageSection, PostCard, Stack, Text } from '@ankhorage/zora';
+import {
+  Badge,
+  IconButton,
+  Page,
+  PageHeader,
+  PageSection,
+  PostCard,
+  Stack,
+  Text,
+} from '@ankhorage/zora';
 import React from 'react';
 import { ScrollView } from 'react-native';
 
@@ -29,11 +38,22 @@ export function PostsPage() {
                 subtitle: '@ada · 2h',
                 avatar: { name: 'Ada Lovelace', tone: 'primary' },
               }}
-              headerAction={<IconButton icon={{ name: 'ellipsis-horizontal-outline' }} label="More post options" />}
+              headerAction={
+                <IconButton
+                  icon={{ name: 'ellipsis-horizontal-outline' }}
+                  label="More post options"
+                />
+              }
               text="Working on a reusable social pattern for ZORA. The card owns the post anatomy; the surrounding screen owns list behavior."
               media={{ source: iconPng, label: 'ZORA showcase icon', aspectRatio: 16 / 9 }}
               actions={[
-                { id: 'like', label: 'Like', icon: { name: 'heart-outline' }, count: 24, onPress: noop },
+                {
+                  id: 'like',
+                  label: 'Like',
+                  icon: { name: 'heart-outline' },
+                  count: 24,
+                  onPress: noop,
+                },
                 {
                   id: 'comment',
                   label: 'Comment',
@@ -66,7 +86,12 @@ export function PostsPage() {
               }}
               text="PostCard also supports compact density for system updates and notification-style content."
               actions={[
-                { id: 'ack', label: 'Acknowledge', icon: { name: 'checkmark-outline' }, onPress: noop },
+                {
+                  id: 'ack',
+                  label: 'Acknowledge',
+                  icon: { name: 'checkmark-outline' },
+                  onPress: noop,
+                },
               ]}
               footer={
                 <Text tone="subtle" variant="caption">
@@ -95,7 +120,12 @@ export function PostsPage() {
               }}
               actions={[
                 { id: 'like', label: 'Like', icon: { name: 'heart-outline' }, onPress: noop },
-                { id: 'comment', label: 'Comment', icon: { name: 'chatbubble-outline' }, onPress: noop },
+                {
+                  id: 'comment',
+                  label: 'Comment',
+                  icon: { name: 'chatbubble-outline' },
+                  onPress: noop,
+                },
               ]}
             />
           </Stack>

--- a/examples/expo-showcase/bun.lock
+++ b/examples/expo-showcase/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "zora-expo-showcase",
       "dependencies": {
-        "@ankhorage/zora": "^1.4.6",
+        "@ankhorage/zora": "^1.4.7",
         "@expo/vector-icons": "^15.0.3",
         "@react-native-picker/picker": "2.11.1",
         "expo": "~54.0.34",
@@ -32,7 +32,7 @@
 
     "@ankhorage/surface": ["@ankhorage/surface@1.3.0", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.4", "@ankhorage/contracts": "^1.2.0" }, "peerDependencies": { "@expo/vector-icons": ">=14.0.0", "expo-font": "^55.0.6", "react": ">=18.2.0", "react-native": ">=0.72.0", "react-native-safe-area-context": "^5.0.0" }, "optionalPeers": ["@expo/vector-icons", "expo-font"] }, "sha512-9mpcqyY5eMQB2XxMF3iKKGZsQxbknA0PUKKDMUr/rsJ5owKEaQwmFKC/MDjfp+jAWcImVABvrOGPid3Pevi9Qg=="],
 
-    "@ankhorage/zora": ["@ankhorage/zora@1.4.6", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.4", "@ankhorage/contracts": "^1.2.0", "@ankhorage/surface": "^1.3.0" }, "peerDependencies": { "@expo/vector-icons": ">=14.0.0", "@react-native-picker/picker": ">=2.0.0", "expo-font": "^55.0.6", "react": ">=18.2.0", "react-native": ">=0.72.0" }, "optionalPeers": ["@expo/vector-icons", "@react-native-picker/picker", "expo-font"] }, "sha512-OmzFJgOzzbnGHbkZLyW8XF9kbr+4oFcxpuKfUjlifH95I1CxlnAw6v57yFT8cdVWwPPIdYAJ6CVxdzGNhbSP3w=="],
+    "@ankhorage/zora": ["@ankhorage/zora@1.4.7", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.4", "@ankhorage/contracts": "^1.2.0", "@ankhorage/surface": "^1.3.0" }, "peerDependencies": { "@expo/vector-icons": ">=14.0.0", "@react-native-picker/picker": ">=2.0.0", "expo-font": "^55.0.6", "react": ">=18.2.0", "react-native": ">=0.72.0" }, "optionalPeers": ["@expo/vector-icons", "@react-native-picker/picker", "expo-font"] }, "sha512-pvJ21y5sGE/6KhNGL4rhWRsQZXhCuAvn8C3UX5O6H3bxuDOBJy4+e1tmbQAS3g4UYssfPYT0ft39WISlBpbjyA=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 

--- a/examples/expo-showcase/package.json
+++ b/examples/expo-showcase/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ankhorage/zora": "^1.4.6",
+    "@ankhorage/zora": "^1.4.7",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-picker/picker": "2.11.1",
     "expo": "~54.0.34",

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,15 @@ export { Notice } from './patterns/notice';
 export type { PanelProps } from './patterns/panel';
 export { Panel } from './patterns/panel';
 export type {
+  PostAction,
+  PostAuthor,
+  PostAuthorAvatar,
+  PostCardMedia,
+  PostCardProps,
+  PostCommentPreview,
+} from './patterns/post-card';
+export { PostCard } from './patterns/post-card';
+export type {
   ResponsivePanelDesktopMode,
   ResponsivePanelMobileMode,
   ResponsivePanelProps,

--- a/src/metadata/allowedChildren.ts
+++ b/src/metadata/allowedChildren.ts
@@ -16,6 +16,7 @@ export const CONTAINER_ALLOWED_CHILDREN = [
   'EmptyState',
   'SectionHeader',
   'SettingsRow',
+  'PostCard',
 ] as const;
 
 export const PAGE_SECTION_ALLOWED_CHILDREN = [...CONTAINER_ALLOWED_CHILDREN] as const;

--- a/src/metadata/componentMeta.test.ts
+++ b/src/metadata/componentMeta.test.ts
@@ -151,6 +151,7 @@ describe('ZORA_COMPONENT_META invariants', () => {
       'Card',
       'Panel',
       'Notice',
+      'PostCard',
       'Box',
       'Stack',
       'Grid',

--- a/src/metadata/componentMeta.ts
+++ b/src/metadata/componentMeta.ts
@@ -55,6 +55,7 @@ import { inspectorFieldMeta } from '../patterns/inspector-field/meta';
 import { listMeta, listRowMeta, listSectionMeta } from '../patterns/list/meta';
 import { noticeMeta } from '../patterns/notice/meta';
 import { panelMeta } from '../patterns/panel/meta';
+import { postCardMeta } from '../patterns/post-card/meta';
 import { responsivePanelMeta } from '../patterns/responsive-panel/meta';
 import { sectionHeaderMeta } from '../patterns/section-header/meta';
 import { selectableItemMeta, selectionProviderMeta } from '../patterns/selection/meta';
@@ -132,6 +133,7 @@ export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   ListSection: listSectionMeta,
   Notice: noticeMeta,
   Panel: panelMeta,
+  PostCard: postCardMeta,
   ResponsivePanel: responsivePanelMeta,
   SectionHeader: sectionHeaderMeta,
   SelectableItem: selectableItemMeta,

--- a/src/patterns/post-card/PostCard.test.tsx
+++ b/src/patterns/post-card/PostCard.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import { describe, expect, test } from 'bun:test';
+import React from 'react';
 
 import { ZORA_COMPONENT_META } from '../../metadata';
 import { PostCard } from './PostCard';

--- a/src/patterns/post-card/PostCard.test.tsx
+++ b/src/patterns/post-card/PostCard.test.tsx
@@ -1,21 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import React from 'react';
 
 import { ZORA_COMPONENT_META } from '../../metadata';
-import { PostCard } from './PostCard';
 
 describe('PostCard', () => {
   test('is registered as a public ZORA pattern', () => {
     expect(ZORA_COMPONENT_META.PostCard?.name).toBe('PostCard');
     expect(ZORA_COMPONENT_META.PostCard?.category).toBe('pattern');
-  });
-
-  test('can be created with the minimal public props', () => {
-    const element = React.createElement(PostCard, {
-      author: { name: 'Ada Lovelace' },
-      text: 'Hello from ZORA.',
-    });
-
-    expect(element.type).toBe(PostCard);
+    expect(ZORA_COMPONENT_META.PostCard?.directManifestNode).toBe(true);
   });
 });

--- a/src/patterns/post-card/PostCard.test.tsx
+++ b/src/patterns/post-card/PostCard.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { describe, expect, test } from 'bun:test';
+
+import { ZORA_COMPONENT_META } from '../../metadata';
+import { PostCard } from './PostCard';
+
+describe('PostCard', () => {
+  test('is registered as a public ZORA pattern', () => {
+    expect(ZORA_COMPONENT_META.PostCard?.name).toBe('PostCard');
+    expect(ZORA_COMPONENT_META.PostCard?.category).toBe('pattern');
+  });
+
+  test('can be created with the minimal public props', () => {
+    const element = React.createElement(PostCard, {
+      author: { name: 'Ada Lovelace' },
+      text: 'Hello from ZORA.',
+    });
+
+    expect(element.type).toBe(PostCard);
+  });
+});

--- a/src/patterns/post-card/PostCard.tsx
+++ b/src/patterns/post-card/PostCard.tsx
@@ -28,12 +28,22 @@ function resolveMediaAspectRatio(aspectRatio: number | undefined): number {
   return aspectRatio;
 }
 
+function isPostCardMediaList(
+  media: NonNullable<PostCardProps['media']>,
+): media is readonly PostCardMedia[] {
+  return Array.isArray(media);
+}
+
 function normalizeMedia(media: PostCardProps['media']): readonly PostCardMedia[] {
   if (!media) {
     return [];
   }
 
-  return Array.isArray(media) ? media : [media];
+  if (isPostCardMediaList(media)) {
+    return media;
+  }
+
+  return [media];
 }
 
 function PostCardAuthor({ author, compact = false }: { author: PostAuthor; compact?: boolean }) {
@@ -180,7 +190,7 @@ function PostCardInner({
   const mediaItems = normalizeMedia(media);
   const gap = compact ? 's' : 'm';
   const isInteractive = Boolean(onPress) && !headerAction;
-  const hasBody = text || children || mediaItems.length > 0;
+  const hasBody = text != null || children != null || mediaItems.length > 0;
   const hasEngagement = actions.length > 0 || comments.length > 0;
 
   return (

--- a/src/patterns/post-card/PostCard.tsx
+++ b/src/patterns/post-card/PostCard.tsx
@@ -38,7 +38,7 @@ function normalizeMedia(media: PostCardProps['media']): readonly PostCardMedia[]
 
 function PostCardAuthor({ author, compact = false }: { author: PostAuthor; compact?: boolean }) {
   const avatarName = resolveAuthorName(author);
-  const avatar = author.avatar;
+  const { avatar } = author;
 
   return (
     <Inline align="center" gap="s" wrap="nowrap">
@@ -184,7 +184,12 @@ function PostCardInner({
   const hasEngagement = actions.length > 0 || comments.length > 0;
 
   return (
-    <Card compact={compact} onPress={isInteractive ? onPress : undefined} testID={testID} tone={tone}>
+    <Card
+      compact={compact}
+      onPress={isInteractive ? onPress : undefined}
+      testID={testID}
+      tone={tone}
+    >
       <Stack gap={gap}>
         <Inline align="center" gap="m" justify="space-between" wrap="nowrap">
           <Box flex={1}>

--- a/src/patterns/post-card/PostCard.tsx
+++ b/src/patterns/post-card/PostCard.tsx
@@ -71,7 +71,7 @@ function PostCardMediaItem({ media }: { media: PostCardMedia }) {
   const { theme } = useZoraTheme();
   const aspectRatio = resolveMediaAspectRatio(media.aspectRatio);
 
-  if (media.children) {
+  if (!('source' in media)) {
     return (
       <Box radius="m" style={{ overflow: 'hidden' }}>
         {media.children}
@@ -92,6 +92,18 @@ function PostCardMediaItem({ media }: { media: PostCardMedia }) {
   );
 }
 
+function PostActionLabel({ action }: { action: PostAction }) {
+  if (!action.count) {
+    return <>{action.label}</>;
+  }
+
+  return (
+    <>
+      {action.label} {action.count}
+    </>
+  );
+}
+
 function PostCardActions({ actions }: { actions: readonly PostAction[] }) {
   if (actions.length === 0) {
     return null;
@@ -109,7 +121,7 @@ function PostCardActions({ actions }: { actions: readonly PostAction[] }) {
           size="s"
           tone={action.selected ? 'primary' : 'neutral'}
         >
-          {action.count ? `${action.label} ${String(action.count)}` : action.label}
+          <PostActionLabel action={action} />
         </Button>
       ))}
     </Inline>

--- a/src/patterns/post-card/PostCard.tsx
+++ b/src/patterns/post-card/PostCard.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import { Image as ReactNativeImage } from 'react-native';
+
+import { Avatar } from '../../components/avatar';
+import { Button } from '../../components/button';
+import { Card } from '../../components/card';
+import { Text } from '../../components/text';
+import { Box, Divider, Inline, Stack } from '../../foundation';
+import { useZoraTheme } from '../../theme/useZoraTheme';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import type {
+  PostAction,
+  PostAuthor,
+  PostCardMedia,
+  PostCardProps,
+  PostCommentPreview,
+} from './types';
+
+function resolveAuthorName(author: PostAuthor): string | undefined {
+  return typeof author.name === 'string' ? author.name : author.avatar?.name;
+}
+
+function resolveMediaAspectRatio(aspectRatio: number | undefined): number {
+  if (aspectRatio === undefined || !Number.isFinite(aspectRatio) || aspectRatio <= 0) {
+    return 16 / 9;
+  }
+
+  return aspectRatio;
+}
+
+function normalizeMedia(media: PostCardProps['media']): readonly PostCardMedia[] {
+  if (!media) {
+    return [];
+  }
+
+  return Array.isArray(media) ? media : [media];
+}
+
+function PostCardAuthor({ author, compact = false }: { author: PostAuthor; compact?: boolean }) {
+  const avatarName = resolveAuthorName(author);
+  const avatar = author.avatar;
+
+  return (
+    <Inline align="center" gap="s" wrap="nowrap">
+      <Avatar
+        initials={avatar?.initials}
+        label={avatar?.label ?? avatarName}
+        name={avatarName}
+        shape={avatar?.shape}
+        size={avatar?.size ?? (compact ? 's' : 'm')}
+        source={avatar?.source}
+        tone={avatar?.tone}
+      />
+      <Box flex={1}>
+        <Stack gap="xxs">
+          <Text variant="bodySmall" weight="semiBold">
+            {author.name}
+          </Text>
+          {author.subtitle ? (
+            <Text tone="muted" variant="caption">
+              {author.subtitle}
+            </Text>
+          ) : null}
+        </Stack>
+      </Box>
+    </Inline>
+  );
+}
+
+function PostCardMediaItem({ media }: { media: PostCardMedia }) {
+  const { theme } = useZoraTheme();
+  const aspectRatio = resolveMediaAspectRatio(media.aspectRatio);
+
+  if (media.children) {
+    return (
+      <Box radius="m" style={{ overflow: 'hidden' }}>
+        {media.children}
+      </Box>
+    );
+  }
+
+  return (
+    <Box bg={theme.semantics.neutral.surface} radius="m" style={{ overflow: 'hidden' }}>
+      <Box style={{ aspectRatio, width: '100%' }}>
+        <ReactNativeImage
+          accessibilityLabel={media.label}
+          source={media.source}
+          style={{ height: '100%', width: '100%' }}
+        />
+      </Box>
+    </Box>
+  );
+}
+
+function PostCardActions({ actions }: { actions: readonly PostAction[] }) {
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <Inline align="center" gap="s" wrap="wrap">
+      {actions.map((action) => (
+        <Button
+          key={action.id}
+          disabled={action.disabled}
+          emphasis={action.selected ? 'soft' : 'ghost'}
+          leadingIcon={action.icon}
+          onPress={action.onPress}
+          size="s"
+          tone={action.selected ? 'primary' : 'neutral'}
+        >
+          {action.count ? `${action.label} ${String(action.count)}` : action.label}
+        </Button>
+      ))}
+    </Inline>
+  );
+}
+
+function PostCommentPreviewItem({ comment }: { comment: PostCommentPreview }) {
+  return (
+    <Inline align="flex-start" gap="s" wrap="nowrap">
+      {comment.author ? <PostCardAuthor author={comment.author} compact /> : null}
+      <Box flex={1}>
+        <Stack gap="xxs">
+          <Text variant="bodySmall">{comment.text}</Text>
+          {comment.meta ? (
+            <Text tone="subtle" variant="caption">
+              {comment.meta}
+            </Text>
+          ) : null}
+          {comment.action ? <Box>{comment.action}</Box> : null}
+        </Stack>
+      </Box>
+    </Inline>
+  );
+}
+
+function PostCardComments({ comments }: { comments: readonly PostCommentPreview[] }) {
+  if (comments.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack gap="s">
+      {comments.map((comment) => (
+        <PostCommentPreviewItem key={comment.id} comment={comment} />
+      ))}
+    </Stack>
+  );
+}
+
+function PostCardInner({
+  themeId: _themeId,
+  mode: _mode,
+  testID,
+  author,
+  text,
+  children,
+  media,
+  actions = [],
+  comments = [],
+  headerAction,
+  footer,
+  tone = 'default',
+  compact = false,
+  onPress,
+}: PostCardProps) {
+  const mediaItems = normalizeMedia(media);
+  const gap = compact ? 's' : 'm';
+  const isInteractive = Boolean(onPress) && !headerAction;
+  const hasBody = text || children || mediaItems.length > 0;
+  const hasEngagement = actions.length > 0 || comments.length > 0;
+
+  return (
+    <Card compact={compact} onPress={isInteractive ? onPress : undefined} testID={testID} tone={tone}>
+      <Stack gap={gap}>
+        <Inline align="center" gap="m" justify="space-between" wrap="nowrap">
+          <Box flex={1}>
+            <PostCardAuthor author={author} compact={compact} />
+          </Box>
+          {headerAction ? <Box>{headerAction}</Box> : null}
+        </Inline>
+
+        {hasBody ? (
+          <Stack gap={gap}>
+            {text ? <Text variant="body">{text}</Text> : null}
+            {children ? <Box>{children}</Box> : null}
+            {mediaItems.length > 0 ? (
+              <Stack gap="s">
+                {mediaItems.map((item, index) => (
+                  <PostCardMediaItem key={`${index}`} media={item} />
+                ))}
+              </Stack>
+            ) : null}
+          </Stack>
+        ) : null}
+
+        {hasEngagement ? <Divider /> : null}
+        <PostCardActions actions={actions} />
+        <PostCardComments comments={comments} />
+        {footer ? <Box pt="xs">{footer}</Box> : null}
+      </Stack>
+    </Card>
+  );
+}
+
+export const PostCard = withZoraThemeScope(PostCardInner);

--- a/src/patterns/post-card/index.ts
+++ b/src/patterns/post-card/index.ts
@@ -1,0 +1,9 @@
+export { PostCard } from './PostCard';
+export type {
+  PostAction,
+  PostAuthor,
+  PostAuthorAvatar,
+  PostCardMedia,
+  PostCardProps,
+  PostCommentPreview,
+} from './types';

--- a/src/patterns/post-card/meta.ts
+++ b/src/patterns/post-card/meta.ts
@@ -1,0 +1,67 @@
+import type { ZoraComponentMeta } from '../../metadata';
+import { CONTAINER_ALLOWED_CHILDREN } from '../../metadata/allowedChildren';
+
+export const postCardMeta = {
+  name: 'PostCard',
+  category: 'pattern',
+  description: 'Social/content post card with author identity, body, media, actions, and comment previews.',
+  directManifestNode: true,
+  allowedChildren: [...CONTAINER_ALLOWED_CHILDREN],
+  blueprint: {
+    label: 'Post card',
+    icon: { name: 'chatbubble-ellipses-outline' },
+    defaultProps: {
+      author: {
+        name: 'Ada Lovelace',
+        subtitle: '@ada · 2h',
+        avatar: {
+          name: 'Ada Lovelace',
+        },
+      },
+      text: 'Share an update, image, or announcement with a reusable ZORA PostCard.',
+    },
+  },
+  props: {
+    author: {
+      type: 'array',
+      category: 'Content',
+      label: 'Author',
+      itemSchema: [
+        {
+          key: 'name',
+          schema: {
+            type: 'string',
+            category: 'Content',
+            label: 'Name',
+          },
+        },
+        {
+          key: 'subtitle',
+          schema: {
+            type: 'string',
+            category: 'Content',
+            label: 'Subtitle',
+          },
+        },
+      ],
+    },
+    text: {
+      type: 'string',
+      category: 'Content',
+      label: 'Text',
+    },
+    compact: {
+      type: 'boolean',
+      category: 'Layout',
+      label: 'Compact',
+      default: false,
+    },
+    tone: {
+      type: 'enum',
+      category: 'Style',
+      label: 'Tone',
+      enum: ['default', 'subtle', 'outline'],
+      default: 'default',
+    },
+  },
+} as const satisfies ZoraComponentMeta;

--- a/src/patterns/post-card/meta.ts
+++ b/src/patterns/post-card/meta.ts
@@ -4,7 +4,8 @@ import { CONTAINER_ALLOWED_CHILDREN } from '../../metadata/allowedChildren';
 export const postCardMeta = {
   name: 'PostCard',
   category: 'pattern',
-  description: 'Social/content post card with author identity, body, media, actions, and comment previews.',
+  description:
+    'Social/content post card with author identity, body, media, actions, and comment previews.',
   directManifestNode: true,
   allowedChildren: [...CONTAINER_ALLOWED_CHILDREN],
   blueprint: {

--- a/src/patterns/post-card/types.ts
+++ b/src/patterns/post-card/types.ts
@@ -1,0 +1,71 @@
+import type { ButtonIconSpec } from '@ankhorage/surface';
+import type React from 'react';
+import type { ImageSourcePropType } from 'react-native';
+
+import type { AvatarShape, AvatarSize } from '../../components/avatar';
+import type { ZoraCardTone, ZoraTone } from '../../internal/recipes';
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export interface PostAuthorAvatar {
+  source?: ImageSourcePropType;
+  name?: string;
+  initials?: string;
+  label?: string;
+  size?: AvatarSize;
+  shape?: AvatarShape;
+  tone?: ZoraTone;
+}
+
+export interface PostAuthor {
+  name: React.ReactNode;
+  subtitle?: React.ReactNode;
+  avatar?: PostAuthorAvatar;
+}
+
+interface PostCardSourceMedia {
+  source: ImageSourcePropType;
+  label: string;
+  aspectRatio?: number;
+  children?: never;
+}
+
+interface PostCardCustomMedia {
+  children: React.ReactNode;
+  label?: string;
+  aspectRatio?: number;
+  source?: never;
+}
+
+export type PostCardMedia = PostCardSourceMedia | PostCardCustomMedia;
+
+export interface PostAction {
+  id: string;
+  label: string;
+  icon?: ButtonIconSpec;
+  count?: React.ReactNode;
+  selected?: boolean;
+  disabled?: boolean;
+  onPress?: () => void;
+}
+
+export interface PostCommentPreview {
+  id: string;
+  author?: PostAuthor;
+  text: React.ReactNode;
+  meta?: React.ReactNode;
+  action?: React.ReactNode;
+}
+
+export interface PostCardProps extends ZoraBaseProps {
+  author: PostAuthor;
+  text?: React.ReactNode;
+  children?: React.ReactNode;
+  media?: PostCardMedia | readonly PostCardMedia[];
+  actions?: readonly PostAction[];
+  comments?: readonly PostCommentPreview[];
+  headerAction?: React.ReactNode;
+  footer?: React.ReactNode;
+  tone?: ZoraCardTone;
+  compact?: boolean;
+  onPress?: () => void;
+}


### PR DESCRIPTION
## Summary

- add a first-class `PostCard` pattern with structured author, media, action, and comment preview props
- export `PostCard` and related public types from `src/index.ts`
- register `PostCard` in component metadata and allowed container children
- add a dedicated Expo showcase `Posts` tab with several `PostCard` examples composed inside `Stack`
- add a patch changeset and a small registration/minimal-props test

## Scope notes

This intentionally does not add `Feed`, `Wall`, `Collection`, `VirtualizedCollection`, pagination, pull-to-refresh, infinite loading, filtering, search state, data fetching, realtime behavior, or comment threads.

`PostCard` is usable standalone, inside `Stack`, inside an app-owned `FlatList`, or inside a future collection/feed abstraction.

## Verification

Not run locally from this environment: the sandbox cannot clone GitHub, so I could not execute Bun commands against the branch. Expected checks:

- `bun run build`
- `bun run lint:fix`
- `bun run test`
- `bun run knip`

Closes #128