### PR TITLE
feat: add ChatListItem pattern

### DIFF
--- a/.changeset/chat-list-item-pattern.md
+++ b/.changeset/chat-list-item-pattern.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Add a reusable ChatListItem pattern with showcase coverage.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ Metadata model overview:
 <details>
 <summary>Patterns</summary>
 
+- `ChatListItem`
 - `CollectionEditor`
 - `ConfirmDialog`
 - `DisclosureSection`
@@ -1524,6 +1525,124 @@ No inherited props. `AuthLayoutProps` is declared directly by ZORA.
 </details>
 
 ## Patterns
+
+### `ChatListItem`
+
+Reusable conversation preview row with avatar, title, preview text, timestamp,
+unread state, selected/open state, and optional trailing content.
+
+`ChatListItem` owns the anatomy of one conversation row. It does not own chat
+list rendering, virtualization, pagination, pull-to-refresh, search/filter state,
+data fetching, realtime behavior, message bubbles, or composer UI. Compose
+multiple rows with `Stack` for short/static groups, or use an app-owned
+`FlatList` for long dynamic chat lists.
+
+```tsx
+import { ChatListItem, Stack } from '@ankhorage/zora';
+
+export function ChatsPreview() {
+  return (
+    <Stack gap="none">
+      <ChatListItem
+        accessibilityLabel="Ada Lovelace, unread, 3 new messages, Can you review the new PostCard API?, 2 minutes ago"
+        avatar={{ name: 'Ada Lovelace', tone: 'primary' }}
+        preview="Can you review the new PostCard API?"
+        timestamp="2m"
+        title="Ada Lovelace"
+        unread
+        unreadCount={3}
+        onPress={() => undefined}
+      />
+
+      <ChatListItem
+        avatar={{ name: 'Grace Hopper', tone: 'success' }}
+        preview="The build is green."
+        timestamp="1h"
+        title="Grace Hopper"
+        onPress={() => undefined}
+      />
+
+      <ChatListItem
+        avatar={{ initials: 'CI', label: 'Build system', tone: 'neutral' }}
+        compact
+        meta="Release automation"
+        preview="Version packages completed for @ankhorage/zora."
+        timestamp="Today"
+        title="Build system"
+      />
+    </Stack>
+  );
+}
+```
+
+For long dynamic chat lists, use an app-owned list renderer:
+
+```tsx
+import { ChatListItem } from '@ankhorage/zora';
+import { FlatList } from 'react-native';
+
+export function ThreadList({ threads }: { threads: Thread[] }) {
+  return (
+    <FlatList
+      data={threads}
+      keyExtractor={(thread) => thread.id}
+      renderItem={({ item }) => (
+        <ChatListItem
+          avatar={{ name: item.title, source: item.avatar }}
+          preview={item.preview}
+          timestamp={item.timestamp}
+          title={item.title}
+          unread={item.unread}
+          unreadCount={item.unreadCount}
+          onPress={() => openThread(item.id)}
+        />
+      )}
+    />
+  );
+}
+```
+
+<details>
+<summary>Props</summary>
+
+ZORA props:
+
+| Prop                 | Type              | Default | Notes                                                                |
+| -------------------- | ----------------- | ------- | -------------------------------------------------------------------- |
+| `title`              | `React.ReactNode` | -       | Required row title, usually the person, group, or conversation name. |
+| `preview`            | `React.ReactNode` | -       | Optional last message or conversation preview.                       |
+| `meta`               | `React.ReactNode` | -       | Optional secondary metadata under the preview.                       |
+| `timestamp`          | `React.ReactNode` | -       | Optional trailing timestamp/meta in the title row.                   |
+| `avatar`             | `ChatListAvatar`  | -       | Optional avatar configuration.                                       |
+| `leading`            | `React.ReactNode` | -       | Optional custom leading slot. Overrides the generated avatar.        |
+| `trailing`           | `React.ReactNode` | -       | Optional trailing slot in the secondary row.                         |
+| `unread`             | `boolean`         | `false` | Emphasizes title/preview/timestamp as unread.                        |
+| `unreadCount`        | `React.ReactNode` | -       | Optional unread count badge content.                                 |
+| `selected`           | `boolean`         | `false` | Marks the row as selected/open.                                      |
+| `disabled`           | `boolean`         | `false` | Disables press handling and renders muted row state.                 |
+| `compact`            | `boolean`         | `false` | Uses tighter vertical padding and smaller avatar defaults.           |
+| `accessibilityLabel` | `string`          | -       | Optional explicit label for interactive rows.                        |
+| `onPress`            | `() => void`      | -       | Makes the row pressable.                                             |
+| `testID`             | `string`          | -       | Test id forwarded to the root row/pressable.                         |
+
+`ChatListAvatar`:
+
+| Prop       | Type                  | Notes                                      |
+| ---------- | --------------------- | ------------------------------------------ |
+| `source`   | `ImageSourcePropType` | Optional avatar image source.              |
+| `name`     | `string`              | Used for fallback initials when available. |
+| `initials` | `string`              | Explicit fallback initials.                |
+| `label`    | `string`              | Accessibility label.                       |
+| `size`     | `AvatarSize`          | Optional avatar size override.             |
+| `shape`    | `AvatarShape`         | Optional avatar shape override.            |
+| `tone`     | `ZoraTone`            | Optional fallback tone.                    |
+
+Inherited props:
+
+No raw style escape hatch is exposed by `ChatListItem`. It uses the underlying
+ZORA `Avatar`, `Badge`, `Text`, and layout primitives internally.
+
+</details>
 
 ### `FormField`
 

--- a/examples/expo-showcase/App.tsx
+++ b/examples/expo-showcase/App.tsx
@@ -12,13 +12,14 @@ import React from 'react';
 import { View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
+import { ChatsPage } from './app/chats';
 import { ComponentsPage } from './app/components';
 import { HomePage } from './app/home';
 import { PatternsPage } from './app/patterns';
 import { PostsPage } from './app/posts';
 import { ThemeComposerPage } from './app/theme-composer';
 
-type ShowcaseTab = 'home' | 'components' | 'patterns' | 'posts' | 'theme';
+type ShowcaseTab = 'home' | 'components' | 'patterns' | 'posts' | 'chats' | 'theme';
 type ColorMode = ZoraThemeMode;
 
 const initialShowcaseTheme: ZoraTheme = {
@@ -50,6 +51,8 @@ function AppWrapper() {
         return <PatternsPage />;
       case 'posts':
         return <PostsPage />;
+      case 'chats':
+        return <ChatsPage />;
       case 'theme':
         return (
           <ThemeComposerPage
@@ -82,6 +85,7 @@ function AppWrapper() {
                   { value: 'components', label: 'Components' },
                   { value: 'patterns', label: 'Patterns' },
                   { value: 'posts', label: 'Posts' },
+                  { value: 'chats', label: 'Chats' },
                   { value: 'theme', label: 'Theme' },
                 ]}
               />

--- a/examples/expo-showcase/app/chats.tsx
+++ b/examples/expo-showcase/app/chats.tsx
@@ -65,7 +65,12 @@ export function ChatsPage() {
               selected
               timestamp="Yesterday"
               title="Maya Chen"
-              trailing={<IconButton icon={{ name: 'ellipsis-horizontal-outline' }} label="More chat actions" />}
+              trailing={
+                <IconButton
+                  icon={{ name: 'ellipsis-horizontal-outline' }}
+                  label="More chat actions"
+                />
+              }
               onPress={noop}
             />
 

--- a/examples/expo-showcase/app/chats.tsx
+++ b/examples/expo-showcase/app/chats.tsx
@@ -1,0 +1,92 @@
+import {
+  Badge,
+  ChatListItem,
+  IconButton,
+  Page,
+  PageHeader,
+  PageSection,
+  Stack,
+  Text,
+} from '@ankhorage/zora';
+import React from 'react';
+import { ScrollView } from 'react-native';
+
+const noop = () => undefined;
+
+export function ChatsPage() {
+  return (
+    <ScrollView>
+      <Page
+        header={
+          <PageHeader
+            eyebrow="ChatListItem pattern"
+            title="Chats"
+            description="Reusable conversation preview rows composed in a plain Stack. ChatList, Collection, and FlatList wrappers are intentionally out of scope for this example."
+          />
+        }
+      >
+        <PageSection
+          title="Stacked conversation previews"
+          description="Use Stack for short/static groups. App-owned FlatList or a future Collection can render the same ChatListItem for long chat lists."
+        >
+          <Stack gap="none">
+            <ChatListItem
+              accessibilityLabel="Ada Lovelace, unread, 3 new messages, Can you review the new PostCard API?, 2 minutes ago"
+              avatar={{ name: 'Ada Lovelace', tone: 'primary' }}
+              preview="Can you review the new PostCard API?"
+              timestamp="2m"
+              title="Ada Lovelace"
+              unread
+              unreadCount={3}
+              onPress={noop}
+            />
+
+            <ChatListItem
+              avatar={{ name: 'Grace Hopper', tone: 'success' }}
+              preview="The build is green."
+              timestamp="1h"
+              title="Grace Hopper"
+              onPress={noop}
+            />
+
+            <ChatListItem
+              avatar={{ initials: 'CI', label: 'Build system', tone: 'neutral' }}
+              compact
+              meta="Release automation"
+              preview="Version packages completed for @ankhorage/zora."
+              timestamp="Today"
+              title="Build system"
+              trailing={<Badge tone="success">Done</Badge>}
+            />
+
+            <ChatListItem
+              avatar={{ name: 'Maya Chen', tone: 'warning' }}
+              preview="Let's revisit the mobile layout before the next pass."
+              selected
+              timestamp="Yesterday"
+              title="Maya Chen"
+              trailing={<IconButton icon={{ name: 'ellipsis-horizontal-outline' }} label="More chat actions" />}
+              onPress={noop}
+            />
+
+            <ChatListItem
+              avatar={{ name: 'Archived thread', tone: 'neutral' }}
+              disabled
+              meta="Archived"
+              preview="This row shows the disabled state."
+              timestamp="Mon"
+              title="Archived thread"
+            />
+          </Stack>
+        </PageSection>
+
+        <PageSection title="Usage note">
+          <Text tone="muted" variant="bodySmall">
+            ChatListItem owns one row. Real long chat lists should use an app-owned FlatList,
+            pagination, refresh, and data loading strategy.
+          </Text>
+        </PageSection>
+      </Page>
+    </ScrollView>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,8 @@ export type {
   SignUpFormValues,
 } from './patterns/auth';
 export { ForgotPasswordForm, OtpForm, SignInForm, SignUpForm } from './patterns/auth';
+export type { ChatListAvatar, ChatListItemProps } from './patterns/chat-list-item';
+export { ChatListItem } from './patterns/chat-list-item';
 export type {
   CollectionEditorProps,
   CollectionEditorRenderItemProps,

--- a/src/metadata/allowedChildren.ts
+++ b/src/metadata/allowedChildren.ts
@@ -17,6 +17,7 @@ export const CONTAINER_ALLOWED_CHILDREN = [
   'SectionHeader',
   'SettingsRow',
   'PostCard',
+  'ChatListItem',
 ] as const;
 
 export const PAGE_SECTION_ALLOWED_CHILDREN = [...CONTAINER_ALLOWED_CHILDREN] as const;

--- a/src/metadata/componentMeta.test.ts
+++ b/src/metadata/componentMeta.test.ts
@@ -141,6 +141,7 @@ describe('ZORA_COMPONENT_META invariants', () => {
       'Text',
       'Heading',
       'Divider',
+      'ChatListItem',
     ]);
 
     const expectedContainerNodes = new Set([

--- a/src/metadata/componentMeta.ts
+++ b/src/metadata/componentMeta.ts
@@ -43,6 +43,7 @@ import {
   signInFormMeta,
   signUpFormMeta,
 } from '../patterns/auth/meta';
+import { chatListItemMeta } from '../patterns/chat-list-item/meta';
 import { collectionEditorMeta } from '../patterns/collection-editor/meta';
 import { confirmDialogMeta } from '../patterns/confirm-dialog/meta';
 import { disclosureSectionMeta } from '../patterns/disclosure-section/meta';
@@ -119,6 +120,7 @@ export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   OtpForm: otpFormMeta,
   SignInForm: signInFormMeta,
   SignUpForm: signUpFormMeta,
+  ChatListItem: chatListItemMeta,
   CollectionEditor: collectionEditorMeta,
   ConfirmDialog: confirmDialogMeta,
   DisclosureSection: disclosureSectionMeta,

--- a/src/patterns/chat-list-item/ChatListItem.test.tsx
+++ b/src/patterns/chat-list-item/ChatListItem.test.tsx
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'bun:test';
+
+import { ZORA_COMPONENT_META } from '../../metadata';
+
+describe('ChatListItem', () => {
+  test('is registered as a public ZORA pattern', () => {
+    expect(ZORA_COMPONENT_META.ChatListItem?.name).toBe('ChatListItem');
+    expect(ZORA_COMPONENT_META.ChatListItem?.category).toBe('pattern');
+    expect(ZORA_COMPONENT_META.ChatListItem?.directManifestNode).toBe(true);
+  });
+});

--- a/src/patterns/chat-list-item/ChatListItem.tsx
+++ b/src/patterns/chat-list-item/ChatListItem.tsx
@@ -98,13 +98,7 @@ function ChatListItemInner({
   const hasUnreadCount = unreadCount != null;
   const hasSecondaryRow = hasPreview || hasMeta || hasUnreadCount || hasTrailing;
 
-  const content = ({
-    pressed,
-    hovered,
-  }: {
-    pressed: boolean;
-    hovered: boolean;
-  }) => {
+  const content = ({ pressed, hovered }: { pressed: boolean; hovered: boolean }) => {
     const styles = resolveContainerStyles({
       theme,
       selected,
@@ -199,11 +193,7 @@ function ChatListItemInner({
   };
 
   if (!isInteractive) {
-    return (
-      <Box testID={testID}>
-        {content({ pressed: false, hovered: false })}
-      </Box>
-    );
+    return <Box testID={testID}>{content({ pressed: false, hovered: false })}</Box>;
   }
 
   return (

--- a/src/patterns/chat-list-item/ChatListItem.tsx
+++ b/src/patterns/chat-list-item/ChatListItem.tsx
@@ -1,0 +1,226 @@
+import { ButtonBase } from '@ankhorage/surface';
+import React from 'react';
+
+import { Avatar } from '../../components/avatar';
+import { Badge } from '../../components/badge';
+import { Text } from '../../components/text';
+import { Box, Inline, Spacer, Stack } from '../../foundation';
+import { useZoraTheme } from '../../theme/useZoraTheme';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import type { ChatListAvatar, ChatListItemProps } from './types';
+
+function resolveAvatarName({
+  avatar,
+  title,
+}: {
+  avatar: ChatListAvatar | undefined;
+  title: React.ReactNode;
+}): string | undefined {
+  if (avatar?.name) {
+    return avatar.name;
+  }
+
+  return typeof title === 'string' ? title : undefined;
+}
+
+function resolvePadding(compact: boolean) {
+  return compact ? { px: 'm' as const, py: 's' as const } : { px: 'm' as const, py: 'm' as const };
+}
+
+function resolveContainerStyles({
+  theme,
+  selected,
+  pressed,
+  hovered,
+  disabled,
+}: {
+  theme: ReturnType<typeof useZoraTheme>['theme'];
+  selected: boolean;
+  pressed: boolean;
+  hovered: boolean;
+  disabled: boolean;
+}) {
+  const borderColor = selected ? theme.semantics.border.focus : 'transparent';
+
+  return {
+    bg: pressed
+      ? theme.semantics.neutral.surfaceActive
+      : hovered
+        ? theme.semantics.neutral.surfaceHover
+        : selected
+          ? theme.semantics.neutral.surface
+          : 'transparent',
+    borderColor,
+    borderWidth: selected ? 1 : 0,
+    opacity: disabled ? 0.72 : 1,
+  };
+}
+
+function renderUnreadCount(unreadCount: React.ReactNode) {
+  if (unreadCount == null) {
+    return null;
+  }
+
+  return (
+    <Badge size="s" tone="primary">
+      {unreadCount}
+    </Badge>
+  );
+}
+
+function ChatListItemInner({
+  themeId: _themeId,
+  mode: _mode,
+  testID,
+  title,
+  preview,
+  meta,
+  timestamp,
+  avatar,
+  leading,
+  trailing,
+  unread = false,
+  unreadCount,
+  selected = false,
+  disabled = false,
+  compact = false,
+  accessibilityLabel,
+  onPress,
+}: ChatListItemProps) {
+  const { theme } = useZoraTheme();
+  const padding = resolvePadding(compact);
+  const avatarName = resolveAvatarName({ avatar, title });
+  const isInteractive = Boolean(onPress);
+
+  const content = ({
+    pressed,
+    hovered,
+  }: {
+    pressed: boolean;
+    hovered: boolean;
+  }) => {
+    const styles = resolveContainerStyles({
+      theme,
+      selected,
+      pressed,
+      hovered,
+      disabled,
+    });
+
+    return (
+      <Box
+        bg={styles.bg}
+        borderColor={styles.borderColor}
+        borderWidth={styles.borderWidth}
+        px={padding.px}
+        py={padding.py}
+        radius="m"
+        style={{ opacity: styles.opacity }}
+      >
+        <Inline align="center" gap="m" wrap="nowrap">
+          {leading ?? (
+            <Avatar
+              initials={avatar?.initials}
+              label={avatar?.label ?? avatarName}
+              name={avatarName}
+              shape={avatar?.shape}
+              size={avatar?.size ?? (compact ? 's' : 'm')}
+              source={avatar?.source}
+              tone={avatar?.tone}
+            />
+          )}
+
+          <Box flex={1}>
+            <Stack gap="xxs">
+              <Inline align="center" gap="s" justify="space-between" wrap="nowrap">
+                <Box flex={1}>
+                  <Text
+                    numberOfLines={1}
+                    tone={disabled ? 'muted' : 'default'}
+                    variant="bodySmall"
+                    weight={unread || selected ? 'semiBold' : 'medium'}
+                  >
+                    {title}
+                  </Text>
+                </Box>
+                {timestamp ? (
+                  <Text
+                    numberOfLines={1}
+                    tone={unread ? 'primary' : 'subtle'}
+                    variant="caption"
+                    weight={unread ? 'semiBold' : 'regular'}
+                  >
+                    {timestamp}
+                  </Text>
+                ) : null}
+              </Inline>
+
+              {preview || meta || unreadCount != null || trailing ? (
+                <Inline align="center" gap="s" justify="space-between" wrap="nowrap">
+                  <Box flex={1}>
+                    <Stack gap="xxs">
+                      {preview ? (
+                        <Text
+                          numberOfLines={1}
+                          tone={unread ? 'default' : 'muted'}
+                          variant="bodySmall"
+                          weight={unread ? 'medium' : 'regular'}
+                        >
+                          {preview}
+                        </Text>
+                      ) : null}
+                      {meta ? (
+                        <Text numberOfLines={1} tone="subtle" variant="caption">
+                          {meta}
+                        </Text>
+                      ) : null}
+                    </Stack>
+                  </Box>
+
+                  {unreadCount != null || trailing ? (
+                    <Inline align="center" gap="s" wrap="nowrap">
+                      {renderUnreadCount(unreadCount)}
+                      {trailing}
+                    </Inline>
+                  ) : null}
+                </Inline>
+              ) : null}
+            </Stack>
+          </Box>
+        </Inline>
+      </Box>
+    );
+  };
+
+  if (!isInteractive) {
+    return (
+      <Box testID={testID}>
+        {content({ pressed: false, hovered: false })}
+      </Box>
+    );
+  }
+
+  return (
+    <ButtonBase
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityState={{ disabled, selected }}
+      disabled={disabled}
+      onPress={onPress}
+      radius="m"
+      testID={testID}
+    >
+      {(state) => (
+        <>
+          {content({
+            pressed: state.pressed,
+            hovered: state.hovered,
+          })}
+          <Spacer size="none" />
+        </>
+      )}
+    </ButtonBase>
+  );
+}
+
+export const ChatListItem = withZoraThemeScope(ChatListItemInner);

--- a/src/patterns/chat-list-item/ChatListItem.tsx
+++ b/src/patterns/chat-list-item/ChatListItem.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Avatar } from '../../components/avatar';
 import { Badge } from '../../components/badge';
 import { Text } from '../../components/text';
-import { Box, Inline, Spacer, Stack } from '../../foundation';
+import { Box, Inline, Stack } from '../../foundation';
 import { useZoraTheme } from '../../theme/useZoraTheme';
 import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
 import type { ChatListAvatar, ChatListItemProps } from './types';
@@ -91,6 +91,12 @@ function ChatListItemInner({
   const padding = resolvePadding(compact);
   const avatarName = resolveAvatarName({ avatar, title });
   const isInteractive = Boolean(onPress);
+  const hasTimestamp = timestamp != null;
+  const hasPreview = preview != null;
+  const hasMeta = meta != null;
+  const hasTrailing = trailing != null;
+  const hasUnreadCount = unreadCount != null;
+  const hasSecondaryRow = hasPreview || hasMeta || hasUnreadCount || hasTrailing;
 
   const content = ({
     pressed,
@@ -143,7 +149,7 @@ function ChatListItemInner({
                     {title}
                   </Text>
                 </Box>
-                {timestamp ? (
+                {hasTimestamp ? (
                   <Text
                     numberOfLines={1}
                     tone={unread ? 'primary' : 'subtle'}
@@ -155,11 +161,11 @@ function ChatListItemInner({
                 ) : null}
               </Inline>
 
-              {preview || meta || unreadCount != null || trailing ? (
+              {hasSecondaryRow ? (
                 <Inline align="center" gap="s" justify="space-between" wrap="nowrap">
                   <Box flex={1}>
                     <Stack gap="xxs">
-                      {preview ? (
+                      {hasPreview ? (
                         <Text
                           numberOfLines={1}
                           tone={unread ? 'default' : 'muted'}
@@ -169,7 +175,7 @@ function ChatListItemInner({
                           {preview}
                         </Text>
                       ) : null}
-                      {meta ? (
+                      {hasMeta ? (
                         <Text numberOfLines={1} tone="subtle" variant="caption">
                           {meta}
                         </Text>
@@ -177,7 +183,7 @@ function ChatListItemInner({
                     </Stack>
                   </Box>
 
-                  {unreadCount != null || trailing ? (
+                  {hasUnreadCount || hasTrailing ? (
                     <Inline align="center" gap="s" wrap="nowrap">
                       {renderUnreadCount(unreadCount)}
                       {trailing}
@@ -210,15 +216,12 @@ function ChatListItemInner({
       radius="m"
       testID={testID}
     >
-      {(state) => (
-        <>
-          {content({
-            pressed: state.pressed,
-            hovered: state.hovered,
-          })}
-          <Spacer size="none" />
-        </>
-      )}
+      {(state) =>
+        content({
+          pressed: state.pressed,
+          hovered: state.hovered,
+        })
+      }
     </ButtonBase>
   );
 }

--- a/src/patterns/chat-list-item/index.ts
+++ b/src/patterns/chat-list-item/index.ts
@@ -1,0 +1,2 @@
+export { ChatListItem } from './ChatListItem';
+export type { ChatListAvatar, ChatListItemProps } from './types';

--- a/src/patterns/chat-list-item/meta.ts
+++ b/src/patterns/chat-list-item/meta.ts
@@ -3,7 +3,8 @@ import type { ZoraComponentMeta } from '../../metadata';
 export const chatListItemMeta = {
   name: 'ChatListItem',
   category: 'pattern',
-  description: 'Conversation preview row with avatar, title, preview text, timestamp, and unread state.',
+  description:
+    'Conversation preview row with avatar, title, preview text, timestamp, and unread state.',
   directManifestNode: true,
   allowedChildren: [],
   blueprint: {

--- a/src/patterns/chat-list-item/meta.ts
+++ b/src/patterns/chat-list-item/meta.ts
@@ -1,0 +1,73 @@
+import type { ZoraComponentMeta } from '../../metadata';
+
+export const chatListItemMeta = {
+  name: 'ChatListItem',
+  category: 'pattern',
+  description: 'Conversation preview row with avatar, title, preview text, timestamp, and unread state.',
+  directManifestNode: true,
+  allowedChildren: [],
+  blueprint: {
+    label: 'Chat list item',
+    icon: { name: 'chatbubble-outline' },
+    defaultProps: {
+      title: 'Ada Lovelace',
+      preview: 'Can you review the latest UI update?',
+      timestamp: '2m',
+      avatar: {
+        name: 'Ada Lovelace',
+      },
+    },
+  },
+  props: {
+    title: {
+      type: 'string',
+      category: 'Content',
+      label: 'Title',
+      default: 'Ada Lovelace',
+    },
+    preview: {
+      type: 'string',
+      category: 'Content',
+      label: 'Preview',
+    },
+    meta: {
+      type: 'string',
+      category: 'Content',
+      label: 'Meta',
+    },
+    timestamp: {
+      type: 'string',
+      category: 'Content',
+      label: 'Timestamp',
+    },
+    unread: {
+      type: 'boolean',
+      category: 'State',
+      label: 'Unread',
+      default: false,
+    },
+    unreadCount: {
+      type: 'string',
+      category: 'State',
+      label: 'Unread count',
+    },
+    selected: {
+      type: 'boolean',
+      category: 'State',
+      label: 'Selected',
+      default: false,
+    },
+    disabled: {
+      type: 'boolean',
+      category: 'State',
+      label: 'Disabled',
+      default: false,
+    },
+    compact: {
+      type: 'boolean',
+      category: 'Layout',
+      label: 'Compact',
+      default: false,
+    },
+  },
+} as const satisfies ZoraComponentMeta;

--- a/src/patterns/chat-list-item/types.ts
+++ b/src/patterns/chat-list-item/types.ts
@@ -1,0 +1,33 @@
+import type React from 'react';
+import type { ImageSourcePropType } from 'react-native';
+
+import type { AvatarShape, AvatarSize } from '../../components/avatar';
+import type { ZoraTone } from '../../internal/recipes';
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export interface ChatListAvatar {
+  source?: ImageSourcePropType;
+  name?: string;
+  initials?: string;
+  label?: string;
+  size?: AvatarSize;
+  shape?: AvatarShape;
+  tone?: ZoraTone;
+}
+
+export interface ChatListItemProps extends ZoraBaseProps {
+  title: React.ReactNode;
+  preview?: React.ReactNode;
+  meta?: React.ReactNode;
+  timestamp?: React.ReactNode;
+  avatar?: ChatListAvatar;
+  leading?: React.ReactNode;
+  trailing?: React.ReactNode;
+  unread?: boolean;
+  unreadCount?: React.ReactNode;
+  selected?: boolean;
+  disabled?: boolean;
+  compact?: boolean;
+  accessibilityLabel?: string;
+  onPress?: () => void;
+}


### PR DESCRIPTION
## Summary

- add a first-class `ChatListItem` pattern with structured avatar, title, preview, timestamp, unread, selected, disabled, leading, and trailing props
- export `ChatListItem` and related public types from `src/index.ts`
- register `ChatListItem` in component metadata and allowed container children
- add a dedicated Expo showcase `Chats` tab with several `ChatListItem` examples composed inside `Stack`
- add a patch changeset and a small metadata registration test

## Scope notes

This intentionally does not add `ChatList`, `Collection`, `VirtualizedCollection`, a ZORA `FlatList` wrapper, pagination, pull-to-refresh, infinite loading, filtering, search state, data fetching, realtime behavior, message bubbles, composer UI, or full chat screens.

`ChatListItem` is usable standalone, inside `Stack`, inside an app-owned `FlatList`, or inside a future collection/chat-list abstraction.

## README

README was not updated in this PR because the connected GitHub file fetch/update flow truncated the current long README content. I can provide a small README patch snippet separately, like the PostCard pass, or we can add README docs in a follow-up commit after CI is green.

## Verification

Not run locally from this environment: the sandbox cannot clone GitHub, so I could not execute Bun commands against the branch. Expected checks:

- `bun run build`
- `bun run lint:fix`
- `bun run test`
- `bun run knip`

Closes #129