### PR TITLE
feat: add MessageBubble pattern

### DIFF
--- a/.changeset/message-bubble-pattern.md
+++ b/.changeset/message-bubble-pattern.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Add a reusable MessageBubble pattern with metadata, exports, and showcase coverage.

--- a/README.md
+++ b/README.md
@@ -2491,6 +2491,109 @@ Inherits all `FormField` props.
 
 </details>
 
+### `MessageBubble`
+
+Reusable chat/message bubble for rendering one message. Use `MessageBubble` for
+message anatomy only; the surrounding screen owns scrolling, keyboard handling,
+pagination, realtime updates, data fetching, and composer behavior.
+
+```tsx
+import { MessageBubble, Stack } from '@ankhorage/zora';
+
+<Stack gap="s">
+  <MessageBubble
+    direction="incoming"
+    author={{
+      name: 'Ada Lovelace',
+      avatar: { name: 'Ada Lovelace', tone: 'primary' },
+    }}
+    text="Can you review the new ChatListItem API?"
+    timestamp="10:41"
+  />
+
+  <MessageBubble
+    direction="outgoing"
+    text="Yes, the row/list boundary looks correct."
+    timestamp="10:42"
+    status="read"
+  />
+
+  <MessageBubble direction="system" compact text="Today" />
+</Stack>;
+```
+
+For long conversations, render `MessageBubble` inside an app-owned list renderer:
+
+```tsx
+import { FlatList } from 'react-native';
+import { MessageBubble } from '@ankhorage/zora';
+
+<FlatList
+  data={messages}
+  keyExtractor={(message) => message.id}
+  renderItem={({ item }) => <MessageBubble {...item} />}
+/>;
+```
+
+Do not use `MessageBubble` as a chat screen, thread manager, composer, or data
+adapter. Future chat/thread abstractions can compose it without changing the
+bubble API.
+
+<details>
+<summary>Props</summary>
+
+ZORA props:
+
+| Prop                 | Type                                     | Default      | Notes                                                                  |
+| -------------------- | ---------------------------------------- | ------------ | ---------------------------------------------------------------------- |
+| `direction`          | `'incoming' \| 'outgoing' \| 'system'`   | `'incoming'` | Controls alignment and visual treatment.                               |
+| `text`               | `React.ReactNode`                        | -            | Main message text.                                                     |
+| `children`           | `React.ReactNode`                        | -            | Custom body slot inside the bubble.                                    |
+| `author`             | `MessageBubbleAuthor`                    | -            | Optional author label/avatar for incoming/group messages.              |
+| `timestamp`          | `React.ReactNode`                        | -            | Optional timestamp rendered in the bubble meta row.                    |
+| `meta`               | `React.ReactNode`                        | -            | Additional meta text.                                                  |
+| `status`             | `MessageBubbleStatus \| React.ReactNode` | -            | Delivery/read status presentation only; no delivery logic is included. |
+| `leading`            | `React.ReactNode`                        | -            | Optional leading slot.                                                 |
+| `trailing`           | `React.ReactNode`                        | -            | Optional trailing slot.                                                |
+| `footer`             | `React.ReactNode`                        | -            | Optional footer below the bubble.                                      |
+| `selected`           | `boolean`                                | `false`      | Highlight/selection state for previews and authoring.                  |
+| `disabled`           | `boolean`                                | `false`      | Muted/disabled presentation and disabled press handling.               |
+| `compact`            | `boolean`                                | `false`      | Uses tighter spacing and a smaller max width.                          |
+| `accessibilityLabel` | `string`                                 | -            | Accessible label used when the bubble is pressable.                    |
+| `onPress`            | `() => void`                             | -            | Makes the bubble pressable.                                            |
+| `testID`             | `string`                                 | -            | Test id.                                                               |
+
+`MessageBubbleStatus`:
+
+```ts
+type MessageBubbleStatus = 'sending' | 'sent' | 'delivered' | 'read' | 'failed';
+```
+
+`MessageBubbleAuthor`:
+
+| Prop     | Type                  | Notes                                       |
+| -------- | --------------------- | ------------------------------------------- |
+| `name`   | `React.ReactNode`     | Optional author label.                      |
+| `avatar` | `MessageBubbleAvatar` | Optional avatar for incoming/group bubbles. |
+
+`MessageBubbleAvatar`:
+
+| Prop       | Type                  | Notes                                           |
+| ---------- | --------------------- | ----------------------------------------------- |
+| `source`   | `ImageSourcePropType` | React Native image source for the avatar.       |
+| `name`     | `string`              | Used to derive initials when `initials` absent. |
+| `initials` | `string`              | Explicit initials override.                     |
+| `label`    | `string`              | Accessibility label.                            |
+| `size`     | `AvatarSize`          | Optional avatar size override.                  |
+| `shape`    | `AvatarShape`         | Optional avatar shape override.                 |
+| `tone`     | `ZoraTone`            | Optional avatar tone.                           |
+
+Inherited props:
+
+No inherited props. `MessageBubbleProps` is declared directly by ZORA.
+
+</details>
+
 ### `SwitchField`
 
 Labeled boolean toggle row.

--- a/examples/expo-showcase/app/chats.tsx
+++ b/examples/expo-showcase/app/chats.tsx
@@ -2,6 +2,7 @@ import {
   Badge,
   ChatListItem,
   IconButton,
+  MessageBubble,
   Page,
   PageHeader,
   PageSection,
@@ -19,9 +20,9 @@ export function ChatsPage() {
       <Page
         header={
           <PageHeader
-            eyebrow="ChatListItem pattern"
+            eyebrow="Chat patterns"
             title="Chats"
-            description="Reusable conversation preview rows composed in a plain Stack. ChatList, Collection, and FlatList wrappers are intentionally out of scope for this example."
+            description="Reusable chat preview rows and message bubbles composed in plain Stack containers. ChatThread, MessageComposer, Collection, and FlatList wrappers are intentionally out of scope for this example."
           />
         }
       >
@@ -85,10 +86,66 @@ export function ChatsPage() {
           </Stack>
         </PageSection>
 
+        <PageSection
+          title="Stacked message bubbles"
+          description="MessageBubble owns one message. The surrounding screen owns scrolling, keyboard handling, realtime updates, pagination, and composer behavior."
+        >
+          <Stack gap="s">
+            <MessageBubble
+              author={{
+                name: 'Ada Lovelace',
+                avatar: { name: 'Ada Lovelace', tone: 'primary' },
+              }}
+              direction="incoming"
+              text="Can you review the new ChatListItem API?"
+              timestamp="10:41"
+              onPress={noop}
+            />
+
+            <MessageBubble
+              direction="outgoing"
+              status="read"
+              text="Yes, the row/list boundary looks correct. MessageBubble should stay independent from the thread renderer too."
+              timestamp="10:42"
+              onPress={noop}
+            />
+
+            <MessageBubble direction="system" compact text="Today" />
+
+            <MessageBubble
+              author={{
+                name: 'Grace Hopper',
+                avatar: { name: 'Grace Hopper', tone: 'success' },
+              }}
+              direction="incoming"
+              meta="Edited"
+              text="Agreed. The bubble can render inside Stack now and inside an app-owned FlatList later."
+              timestamp="10:44"
+            />
+
+            <MessageBubble
+              direction="outgoing"
+              selected
+              status="delivered"
+              text="Selected state is useful for authoring previews and future message selection work."
+              timestamp="10:45"
+            />
+
+            <MessageBubble
+              compact
+              direction="outgoing"
+              disabled
+              status="failed"
+              text="Disabled and failed states can be previewed without adding delivery logic."
+              timestamp="10:46"
+            />
+          </Stack>
+        </PageSection>
+
         <PageSection title="Usage note">
           <Text tone="muted" variant="bodySmall">
-            ChatListItem owns one row. Real long chat lists should use an app-owned FlatList,
-            pagination, refresh, and data loading strategy.
+            ChatListItem and MessageBubble own presentation only. Real long chat lists should use an
+            app-owned FlatList, pagination, refresh, keyboard handling, and data loading strategy.
           </Text>
         </PageSection>
       </Page>

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,14 +166,6 @@ export { ForgotPasswordForm, OtpForm, SignInForm, SignUpForm } from './patterns/
 export type { ChatListAvatar, ChatListItemProps } from './patterns/chat-list-item';
 export { ChatListItem } from './patterns/chat-list-item';
 export type {
-  MessageBubbleAuthor,
-  MessageBubbleAvatar,
-  MessageBubbleDirection,
-  MessageBubbleProps,
-  MessageBubbleStatus,
-} from './patterns/message-bubble';
-export { MessageBubble } from './patterns/message-bubble';
-export type {
   CollectionEditorProps,
   CollectionEditorRenderItemProps,
 } from './patterns/collection-editor';
@@ -211,6 +203,14 @@ export type {
   ListSectionProps,
 } from './patterns/list';
 export { List, ListRow, ListSection } from './patterns/list';
+export type {
+  MessageBubbleAuthor,
+  MessageBubbleAvatar,
+  MessageBubbleDirection,
+  MessageBubbleProps,
+  MessageBubbleStatus,
+} from './patterns/message-bubble';
+export { MessageBubble } from './patterns/message-bubble';
 export type { NoticeProps } from './patterns/notice';
 export { Notice } from './patterns/notice';
 export type { PanelProps } from './patterns/panel';

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,14 @@ export { ForgotPasswordForm, OtpForm, SignInForm, SignUpForm } from './patterns/
 export type { ChatListAvatar, ChatListItemProps } from './patterns/chat-list-item';
 export { ChatListItem } from './patterns/chat-list-item';
 export type {
+  MessageBubbleAuthor,
+  MessageBubbleAvatar,
+  MessageBubbleDirection,
+  MessageBubbleProps,
+  MessageBubbleStatus,
+} from './patterns/message-bubble';
+export { MessageBubble } from './patterns/message-bubble';
+export type {
   CollectionEditorProps,
   CollectionEditorRenderItemProps,
 } from './patterns/collection-editor';

--- a/src/metadata/allowedChildren.ts
+++ b/src/metadata/allowedChildren.ts
@@ -18,6 +18,7 @@ export const CONTAINER_ALLOWED_CHILDREN = [
   'SettingsRow',
   'PostCard',
   'ChatListItem',
+  'MessageBubble',
 ] as const;
 
 export const PAGE_SECTION_ALLOWED_CHILDREN = [...CONTAINER_ALLOWED_CHILDREN] as const;

--- a/src/metadata/componentMeta.test.ts
+++ b/src/metadata/componentMeta.test.ts
@@ -153,6 +153,7 @@ describe('ZORA_COMPONENT_META invariants', () => {
       'Panel',
       'Notice',
       'PostCard',
+      'MessageBubble',
       'Box',
       'Stack',
       'Grid',

--- a/src/metadata/componentMeta.ts
+++ b/src/metadata/componentMeta.ts
@@ -54,6 +54,7 @@ import { imagePreviewMeta } from '../patterns/image-preview/meta';
 import { imageUploadFieldMeta } from '../patterns/image-upload-field/meta';
 import { inspectorFieldMeta } from '../patterns/inspector-field/meta';
 import { listMeta, listRowMeta, listSectionMeta } from '../patterns/list/meta';
+import { messageBubbleMeta } from '../patterns/message-bubble/meta';
 import { noticeMeta } from '../patterns/notice/meta';
 import { panelMeta } from '../patterns/panel/meta';
 import { postCardMeta } from '../patterns/post-card/meta';
@@ -133,6 +134,7 @@ export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   List: listMeta,
   ListRow: listRowMeta,
   ListSection: listSectionMeta,
+  MessageBubble: messageBubbleMeta,
   Notice: noticeMeta,
   Panel: panelMeta,
   PostCard: postCardMeta,

--- a/src/patterns/message-bubble/MessageBubble.tsx
+++ b/src/patterns/message-bubble/MessageBubble.tsx
@@ -1,0 +1,249 @@
+import { ButtonBase } from '@ankhorage/surface';
+import React from 'react';
+
+import { Avatar } from '../../components/avatar';
+import { Text } from '../../components/text';
+import { Box, Inline, Stack } from '../../foundation';
+import { useZoraTheme } from '../../theme/useZoraTheme';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import type {
+  MessageBubbleAvatar,
+  MessageBubbleDirection,
+  MessageBubbleProps,
+  MessageBubbleStatus,
+} from './types';
+
+function resolveAvatarName({
+  avatar,
+  authorName,
+}: {
+  avatar: MessageBubbleAvatar | undefined;
+  authorName: React.ReactNode | undefined;
+}): string | undefined {
+  if (avatar?.name) return avatar.name;
+  return typeof authorName === 'string' ? authorName : undefined;
+}
+
+function resolvePadding(compact: boolean) {
+  return compact ? { px: 'm' as const, py: 's' as const } : { px: 'm' as const, py: 'm' as const };
+}
+
+function resolveStatusLabel(status: MessageBubbleStatus): string {
+  switch (status) {
+    case 'sending':
+      return 'Sending';
+    case 'sent':
+      return 'Sent';
+    case 'delivered':
+      return 'Delivered';
+    case 'read':
+      return 'Read';
+    case 'failed':
+      return 'Failed';
+    default:
+      return status;
+  }
+}
+
+function isMessageBubbleStatus(status: MessageBubbleProps['status']): status is MessageBubbleStatus {
+  return (
+    status === 'sending' ||
+    status === 'sent' ||
+    status === 'delivered' ||
+    status === 'read' ||
+    status === 'failed'
+  );
+}
+
+function resolveStatus(status: MessageBubbleProps['status']) {
+  if (status == null) return null;
+  return isMessageBubbleStatus(status) ? resolveStatusLabel(status) : status;
+}
+
+function resolveBubbleStyles({
+  direction,
+  disabled,
+  hovered,
+  pressed,
+  selected,
+  theme,
+}: {
+  direction: MessageBubbleDirection;
+  disabled: boolean;
+  hovered: boolean;
+  pressed: boolean;
+  selected: boolean;
+  theme: ReturnType<typeof useZoraTheme>['theme'];
+}) {
+  const borderColor = selected ? theme.semantics.border.focus : theme.semantics.border.default;
+
+  if (direction === 'system') {
+    return {
+      bg: selected ? theme.semantics.neutral.surface : 'transparent',
+      borderColor,
+      borderWidth: selected ? 1 : 0,
+      opacity: disabled ? 0.72 : 1,
+    };
+  }
+
+  const interactiveBg = pressed
+    ? theme.semantics.neutral.surfaceActive
+    : hovered
+      ? theme.semantics.neutral.surfaceHover
+      : undefined;
+
+  return {
+    bg:
+      interactiveBg ??
+      (direction === 'outgoing' ? theme.semantics.neutral.surface : theme.semantics.surface.raised),
+    borderColor,
+    borderWidth: selected ? 1 : 0,
+    opacity: disabled ? 0.72 : 1,
+  };
+}
+
+function MessageAvatar({
+  avatar,
+  authorName,
+  compact,
+}: {
+  avatar: MessageBubbleAvatar;
+  authorName: React.ReactNode | undefined;
+  compact: boolean;
+}) {
+  const avatarName = resolveAvatarName({ avatar, authorName });
+
+  return (
+    <Avatar
+      initials={avatar.initials}
+      label={avatar.label ?? avatarName}
+      name={avatarName}
+      shape={avatar.shape}
+      size={avatar.size ?? (compact ? 'xs' : 's')}
+      source={avatar.source}
+      tone={avatar.tone}
+    />
+  );
+}
+
+function MessageBubbleInner({
+  themeId: _themeId,
+  mode: _mode,
+  testID,
+  direction = 'incoming',
+  text,
+  children,
+  author,
+  timestamp,
+  meta,
+  status,
+  leading,
+  trailing,
+  footer,
+  selected = false,
+  disabled = false,
+  compact = false,
+  accessibilityLabel,
+  onPress,
+}: MessageBubbleProps) {
+  const { theme } = useZoraTheme();
+  const padding = resolvePadding(compact);
+  const isInteractive = Boolean(onPress);
+  const isOutgoing = direction === 'outgoing';
+  const isSystem = direction === 'system';
+  const renderedStatus = resolveStatus(status);
+  const hasAuthorName = author?.name != null && !isOutgoing && !isSystem;
+  const hasAvatar = author?.avatar != null && !isOutgoing && !isSystem;
+  const hasMetaRow = timestamp != null || meta != null || renderedStatus != null;
+
+  const renderBubble = ({ pressed, hovered }: { pressed: boolean; hovered: boolean }) => {
+    const styles = resolveBubbleStyles({ direction, disabled, hovered, pressed, selected, theme });
+
+    return (
+      <Box
+        bg={styles.bg}
+        borderColor={styles.borderColor}
+        borderWidth={styles.borderWidth}
+        px={padding.px}
+        py={padding.py}
+        radius={isSystem ? 'm' : 'l'}
+        style={{ maxWidth: compact ? 420 : 560, opacity: styles.opacity }}
+      >
+        <Stack align={isSystem ? 'center' : 'flex-start'} gap={compact ? 'xxs' : 'xs'}>
+          {hasAuthorName ? (
+            <Text tone="muted" variant="caption" weight="semiBold">
+              {author?.name}
+            </Text>
+          ) : null}
+          {text != null ? (
+            <Text align={isSystem ? 'center' : undefined} tone={disabled ? 'muted' : 'default'}>
+              {text}
+            </Text>
+          ) : null}
+          {children != null ? <Box width="100%">{children}</Box> : null}
+          {hasMetaRow ? (
+            <Inline
+              align="center"
+              gap="xs"
+              justify={isOutgoing ? 'flex-end' : isSystem ? 'center' : 'flex-start'}
+              wrap="wrap"
+            >
+              {timestamp != null ? <Text tone="subtle" variant="caption">{timestamp}</Text> : null}
+              {meta != null ? <Text tone="subtle" variant="caption">{meta}</Text> : null}
+              {renderedStatus != null ? (
+                <Text tone={status === 'failed' ? 'danger' : 'subtle'} variant="caption">
+                  {renderedStatus}
+                </Text>
+              ) : null}
+            </Inline>
+          ) : null}
+        </Stack>
+      </Box>
+    );
+  };
+
+  const bubbleContent = isInteractive ? (
+    <ButtonBase
+      accessibilityLabel={accessibilityLabel}
+      accessibilityRole="button"
+      accessibilityState={{ disabled, selected }}
+      disabled={disabled}
+      onPress={onPress}
+      radius={isSystem ? 'm' : 'l'}
+      testID={testID}
+    >
+      {(state) => renderBubble({ pressed: state.pressed, hovered: state.hovered })}
+    </ButtonBase>
+  ) : (
+    <Box testID={testID}>{renderBubble({ pressed: false, hovered: false })}</Box>
+  );
+
+  return (
+    <Stack gap="xs" style={{ width: '100%' }}>
+      <Inline
+        align="flex-end"
+        gap="s"
+        justify={isSystem ? 'center' : isOutgoing ? 'flex-end' : 'flex-start'}
+        wrap="nowrap"
+      >
+        {!isOutgoing && !isSystem ? (
+          <Box>
+            {leading ??
+              (hasAvatar && author?.avatar ? (
+                <MessageAvatar avatar={author.avatar} authorName={author.name} compact={compact} />
+              ) : null)}
+          </Box>
+        ) : null}
+        {isOutgoing && trailing ? <Box>{trailing}</Box> : null}
+        {bubbleContent}
+        {isOutgoing && leading ? <Box>{leading}</Box> : null}
+        {!isOutgoing && !isSystem && trailing ? <Box>{trailing}</Box> : null}
+      </Inline>
+      {footer != null ? (
+        <Box alignSelf={isOutgoing ? 'flex-end' : isSystem ? 'center' : 'flex-start'}>{footer}</Box>
+      ) : null}
+    </Stack>
+  );
+}
+
+export const MessageBubble = withZoraThemeScope(MessageBubbleInner);

--- a/src/patterns/message-bubble/MessageBubble.tsx
+++ b/src/patterns/message-bubble/MessageBubble.tsx
@@ -154,8 +154,10 @@ function MessageBubbleInner({
   const isOutgoing = direction === 'outgoing';
   const isSystem = direction === 'system';
   const renderedStatus = resolveStatus(status);
-  const hasAuthorName = author?.name != null && !isOutgoing && !isSystem;
-  const hasAvatar = author?.avatar != null && !isOutgoing && !isSystem;
+  const authorName = author?.name;
+  const authorAvatar = author?.avatar;
+  const hasAuthorName = authorName != null && !isOutgoing && !isSystem;
+  const hasAvatar = authorAvatar != null && !isOutgoing && !isSystem;
   const hasMetaRow = timestamp != null || meta != null || renderedStatus != null;
 
   const renderBubble = ({ pressed, hovered }: { pressed: boolean; hovered: boolean }) => {
@@ -174,7 +176,7 @@ function MessageBubbleInner({
         <Stack align={isSystem ? 'center' : 'flex-start'} gap={compact ? 'xxs' : 'xs'}>
           {hasAuthorName ? (
             <Text tone="muted" variant="caption" weight="semiBold">
-              {author?.name}
+              {authorName}
             </Text>
           ) : null}
           {text != null ? (
@@ -239,8 +241,8 @@ function MessageBubbleInner({
         {!isOutgoing && !isSystem ? (
           <Box>
             {leading ??
-              (hasAvatar && author?.avatar ? (
-                <MessageAvatar avatar={author.avatar} authorName={author.name} compact={compact} />
+              (hasAvatar ? (
+                <MessageAvatar avatar={authorAvatar} authorName={authorName} compact={compact} />
               ) : null)}
           </Box>
         ) : null}

--- a/src/patterns/message-bubble/MessageBubble.tsx
+++ b/src/patterns/message-bubble/MessageBubble.tsx
@@ -45,7 +45,9 @@ function resolveStatusLabel(status: MessageBubbleStatus): string {
   }
 }
 
-function isMessageBubbleStatus(status: MessageBubbleProps['status']): status is MessageBubbleStatus {
+function isMessageBubbleStatus(
+  status: MessageBubbleProps['status'],
+): status is MessageBubbleStatus {
   return (
     status === 'sending' ||
     status === 'sent' ||
@@ -188,8 +190,16 @@ function MessageBubbleInner({
               justify={isOutgoing ? 'flex-end' : isSystem ? 'center' : 'flex-start'}
               wrap="wrap"
             >
-              {timestamp != null ? <Text tone="subtle" variant="caption">{timestamp}</Text> : null}
-              {meta != null ? <Text tone="subtle" variant="caption">{meta}</Text> : null}
+              {timestamp != null ? (
+                <Text tone="subtle" variant="caption">
+                  {timestamp}
+                </Text>
+              ) : null}
+              {meta != null ? (
+                <Text tone="subtle" variant="caption">
+                  {meta}
+                </Text>
+              ) : null}
               {renderedStatus != null ? (
                 <Text tone={status === 'failed' ? 'danger' : 'subtle'} variant="caption">
                   {renderedStatus}

--- a/src/patterns/message-bubble/index.ts
+++ b/src/patterns/message-bubble/index.ts
@@ -1,0 +1,8 @@
+export { MessageBubble } from './MessageBubble';
+export type {
+  MessageBubbleAuthor,
+  MessageBubbleAvatar,
+  MessageBubbleDirection,
+  MessageBubbleProps,
+  MessageBubbleStatus,
+} from './types';

--- a/src/patterns/message-bubble/meta.ts
+++ b/src/patterns/message-bubble/meta.ts
@@ -4,7 +4,8 @@ import { CONTAINER_ALLOWED_CHILDREN } from '../../metadata/allowedChildren';
 export const messageBubbleMeta = {
   name: 'MessageBubble',
   category: 'pattern',
-  description: 'Chat/message bubble with direction, author, text, meta, and delivery status presentation.',
+  description:
+    'Chat/message bubble with direction, author, text, meta, and delivery status presentation.',
   directManifestNode: true,
   allowedChildren: [...CONTAINER_ALLOWED_CHILDREN],
   blueprint: {

--- a/src/patterns/message-bubble/meta.ts
+++ b/src/patterns/message-bubble/meta.ts
@@ -1,0 +1,67 @@
+import type { ZoraComponentMeta } from '../../metadata';
+import { CONTAINER_ALLOWED_CHILDREN } from '../../metadata/allowedChildren';
+
+export const messageBubbleMeta = {
+  name: 'MessageBubble',
+  category: 'pattern',
+  description: 'Chat/message bubble with direction, author, text, meta, and delivery status presentation.',
+  directManifestNode: true,
+  allowedChildren: [...CONTAINER_ALLOWED_CHILDREN],
+  blueprint: {
+    label: 'Message bubble',
+    icon: { name: 'chatbubble-outline' },
+    defaultProps: {
+      direction: 'incoming',
+      text: 'Can you review the latest message pattern?',
+      timestamp: '10:41',
+    },
+  },
+  props: {
+    direction: {
+      type: 'enum',
+      category: 'Content',
+      label: 'Direction',
+      enum: ['incoming', 'outgoing', 'system'],
+      default: 'incoming',
+    },
+    text: {
+      type: 'string',
+      category: 'Content',
+      label: 'Text',
+    },
+    timestamp: {
+      type: 'string',
+      category: 'Content',
+      label: 'Timestamp',
+    },
+    meta: {
+      type: 'string',
+      category: 'Content',
+      label: 'Meta',
+    },
+    status: {
+      type: 'enum',
+      category: 'Content',
+      label: 'Status',
+      enum: ['sending', 'sent', 'delivered', 'read', 'failed'],
+    },
+    selected: {
+      type: 'boolean',
+      category: 'State',
+      label: 'Selected',
+      default: false,
+    },
+    disabled: {
+      type: 'boolean',
+      category: 'State',
+      label: 'Disabled',
+      default: false,
+    },
+    compact: {
+      type: 'boolean',
+      category: 'Layout',
+      label: 'Compact',
+      default: false,
+    },
+  },
+} as const satisfies ZoraComponentMeta;

--- a/src/patterns/message-bubble/types.ts
+++ b/src/patterns/message-bubble/types.ts
@@ -7,6 +7,7 @@ import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 
 export type MessageBubbleDirection = 'incoming' | 'outgoing' | 'system';
 export type MessageBubbleStatus = 'sending' | 'sent' | 'delivered' | 'read' | 'failed';
+export type MessageBubbleStatusContent = MessageBubbleStatus | Exclude<React.ReactNode, string>;
 
 export interface MessageBubbleAvatar {
   source?: ImageSourcePropType;
@@ -30,7 +31,7 @@ export interface MessageBubbleProps extends ZoraBaseProps {
   author?: MessageBubbleAuthor;
   timestamp?: React.ReactNode;
   meta?: React.ReactNode;
-  status?: MessageBubbleStatus | React.ReactNode;
+  status?: MessageBubbleStatusContent;
   leading?: React.ReactNode;
   trailing?: React.ReactNode;
   footer?: React.ReactNode;

--- a/src/patterns/message-bubble/types.ts
+++ b/src/patterns/message-bubble/types.ts
@@ -7,7 +7,7 @@ import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 
 export type MessageBubbleDirection = 'incoming' | 'outgoing' | 'system';
 export type MessageBubbleStatus = 'sending' | 'sent' | 'delivered' | 'read' | 'failed';
-export type MessageBubbleStatusContent = MessageBubbleStatus | Exclude<React.ReactNode, string>;
+type MessageBubbleStatusContent = MessageBubbleStatus | Exclude<React.ReactNode, string>;
 
 export interface MessageBubbleAvatar {
   source?: ImageSourcePropType;

--- a/src/patterns/message-bubble/types.ts
+++ b/src/patterns/message-bubble/types.ts
@@ -1,0 +1,42 @@
+import type React from 'react';
+import type { ImageSourcePropType } from 'react-native';
+
+import type { AvatarShape, AvatarSize } from '../../components/avatar';
+import type { ZoraTone } from '../../internal/recipes';
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export type MessageBubbleDirection = 'incoming' | 'outgoing' | 'system';
+export type MessageBubbleStatus = 'sending' | 'sent' | 'delivered' | 'read' | 'failed';
+
+export interface MessageBubbleAvatar {
+  source?: ImageSourcePropType;
+  name?: string;
+  initials?: string;
+  label?: string;
+  size?: AvatarSize;
+  shape?: AvatarShape;
+  tone?: ZoraTone;
+}
+
+export interface MessageBubbleAuthor {
+  name?: React.ReactNode;
+  avatar?: MessageBubbleAvatar;
+}
+
+export interface MessageBubbleProps extends ZoraBaseProps {
+  direction?: MessageBubbleDirection;
+  text?: React.ReactNode;
+  children?: React.ReactNode;
+  author?: MessageBubbleAuthor;
+  timestamp?: React.ReactNode;
+  meta?: React.ReactNode;
+  status?: MessageBubbleStatus | React.ReactNode;
+  leading?: React.ReactNode;
+  trailing?: React.ReactNode;
+  footer?: React.ReactNode;
+  selected?: boolean;
+  disabled?: boolean;
+  compact?: boolean;
+  accessibilityLabel?: string;
+  onPress?: () => void;
+}


### PR DESCRIPTION
## Summary

- Add the public `MessageBubble` pattern with structured direction, author/avatar, text/body, meta, status, selection, disabled, compact, and press props.
- Register `MessageBubble` in public exports, component metadata, container allowed-children metadata, and metadata invariant tests.
- Extend the Expo showcase `Chats` page with stacked incoming, outgoing, system, selected, disabled, and failed-state message bubbles.
- Add a README `MessageBubble` section with Stack and app-owned FlatList usage examples.
- Add a patch changeset for the published API addition.

## Scope

This intentionally does not add `ChatScreen`, `ChatThread`, `MessageComposer`, `FlatList` wrappers, virtualization, realtime behavior, pagination, keyboard avoidance, delivery logic, persistence, or provider-specific chat logic.

`MessageBubble` remains a presentation pattern that can be used standalone, inside `Stack`, inside app-owned list renderers, or by future ZORA chat/thread abstractions.

## Verification

CI is green. Local checks reported by maintainer:

- `bun run build`
- `bun run lint:fix`
- `bun run test`
- `bun run knip`