### PR TITLE
feat(examples): improve responsive density and visual identity

### DIFF
--- a/.changeset/fresh-badgers-density.md
+++ b/.changeset/fresh-badgers-density.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/zora": patch
+---
+
+Improve realistic example density with responsive ListSection and ScreenSection grid behavior, distinct example theme seeds, and a visual QA checklist.

--- a/.changeset/fresh-badgers-density.md
+++ b/.changeset/fresh-badgers-density.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/zora": patch
+'@ankhorage/zora': patch
 ---
 
 Improve realistic example density with responsive ListSection and ScreenSection grid behavior, distinct example theme seeds, and a visual QA checklist.

--- a/docs/realistic-example-visual-qa.md
+++ b/docs/realistic-example-visual-qa.md
@@ -1,0 +1,25 @@
+# Realistic example visual QA
+
+Use this checklist when changing `examples/{category}/{example-id}` apps.
+
+## Layout density
+
+- Mobile screens should show meaningful content above the fold.
+- Tablet and desktop widths should use horizontal space instead of stacking every card vertically.
+- Repeated `ListSection` card rows should use the ZORA responsive list grid behavior instead of route-local wrappers.
+- Metric/card overview sections should use `ScreenSection` responsive columns where the content is naturally parallel.
+
+## Visual identity
+
+- Every realistic example should define an app-level `ZoraTheme` in its root layout.
+- Theme seeds should differ by app category and product feel.
+- Repeated imagery across examples should be avoided when it makes apps feel generic.
+- AppBar chrome should stay compact: title plus persistent actions such as the dark-mode toggle.
+- Badges, counters, avatars, and large buttons belong in content sections, not in the AppBar.
+
+## Constraints
+
+- Use public `@ankhorage/zora` exports only.
+- Do not import `@ankhorage/surface` directly from examples.
+- Do not add `StyleSheet` or raw React Native layout hacks to examples.
+- If a layout feels wrong, improve a ZORA component or pattern.

--- a/examples/food_drink/restaurant/app/(tabs)/orders.tsx
+++ b/examples/food_drink/restaurant/app/(tabs)/orders.tsx
@@ -28,7 +28,7 @@ export default function OrdersScreen() {
     <>
       <ExampleAppBar title="Orders" />
       <Screen>
-        <ScreenSection title="Today">
+        <ScreenSection title="Today" columns={{ base: 1, md: 3 }}>
           <MetricCard label="Open orders" value="2" description="Dining and takeaway" />
           <MetricCard
             label="Ready soon"

--- a/examples/food_drink/restaurant/app/(tabs)/profile.tsx
+++ b/examples/food_drink/restaurant/app/(tabs)/profile.tsx
@@ -40,7 +40,7 @@ export default function ProfileScreen() {
           </Card>
         </ScreenSection>
 
-        <ScreenSection title="Guest stats">
+        <ScreenSection title="Guest stats" columns={{ base: 1, md: 3 }}>
           <MetricCard label="Visits" value="18" description="Lifetime reservations" />
           <MetricCard
             label="Upcoming"

--- a/examples/food_drink/restaurant/app/_layout.tsx
+++ b/examples/food_drink/restaurant/app/_layout.tsx
@@ -1,9 +1,17 @@
-import { ZoraProvider } from '@ankhorage/zora';
+import { ZoraProvider, type ZoraTheme } from '@ankhorage/zora';
 import { Stack } from 'expo-router';
+
+const theme: ZoraTheme = {
+  id: 'restaurant',
+  name: 'Restaurant',
+  appCategory: 'food_drink',
+  primaryColor: '#16a34a',
+  harmony: 'complementary',
+};
 
 export default function RootLayout() {
   return (
-    <ZoraProvider>
+    <ZoraProvider theme={theme}>
       <Stack screenOptions={{ headerShown: false }} />
     </ZoraProvider>
   );

--- a/examples/food_drink/restaurant/package.json
+++ b/examples/food_drink/restaurant/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ankhorage/zora": "^1.4.12",
+    "@ankhorage/zora": "^1.5.1",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-picker/picker": "2.11.1",
     "expo": "~54.0.34",

--- a/examples/shopping_commerce/marketplace/app/(tabs)/orders.tsx
+++ b/examples/shopping_commerce/marketplace/app/(tabs)/orders.tsx
@@ -28,7 +28,11 @@ export default function OrdersScreen() {
     <>
       <ExampleAppBar title="Orders" />
       <Screen>
-        <ScreenSection title="Summary" actions={<Badge tone="primary">3 active</Badge>}>
+        <ScreenSection
+          title="Summary"
+          actions={<Badge tone="primary">3 active</Badge>}
+          columns={{ base: 1, md: 3 }}
+        >
           <MetricCard label="Active orders" value="3" description="Purchases and offers" />
           <MetricCard
             label="Pending pickup"

--- a/examples/shopping_commerce/marketplace/app/(tabs)/profile.tsx
+++ b/examples/shopping_commerce/marketplace/app/(tabs)/profile.tsx
@@ -53,7 +53,7 @@ export default function ProfileScreen() {
           </Card>
         </ScreenSection>
 
-        <ScreenSection title="Stats">
+        <ScreenSection title="Stats" columns={{ base: 1, md: 3 }}>
           <MetricCard label="Rating" value="4.9" description="42 reviews" />
           <MetricCard
             label="Sold"

--- a/examples/shopping_commerce/marketplace/app/_layout.tsx
+++ b/examples/shopping_commerce/marketplace/app/_layout.tsx
@@ -1,9 +1,17 @@
-import { ZoraProvider } from '@ankhorage/zora';
+import { ZoraProvider, type ZoraTheme } from '@ankhorage/zora';
 import { Stack } from 'expo-router';
+
+const theme: ZoraTheme = {
+  id: 'marketplace',
+  name: 'Marketplace',
+  appCategory: 'shopping_commerce',
+  primaryColor: '#ea580c',
+  harmony: 'splitComplementary',
+};
 
 export default function RootLayout() {
   return (
-    <ZoraProvider>
+    <ZoraProvider theme={theme}>
       <Stack screenOptions={{ headerShown: false }} />
     </ZoraProvider>
   );

--- a/examples/shopping_commerce/storefront/app/(tabs)/orders.tsx
+++ b/examples/shopping_commerce/storefront/app/(tabs)/orders.tsx
@@ -28,7 +28,11 @@ export default function OrdersScreen() {
     <>
       <ExampleAppBar title="Orders" />
       <Screen>
-        <ScreenSection title="Order health" actions={<Badge tone="primary">1 active</Badge>}>
+        <ScreenSection
+          title="Order health"
+          actions={<Badge tone="primary">1 active</Badge>}
+          columns={{ base: 1, md: 3 }}
+        >
           <MetricCard label="Open orders" value="1" description="Preparing shipment" />
           <MetricCard
             label="Delivered"

--- a/examples/shopping_commerce/storefront/app/(tabs)/profile.tsx
+++ b/examples/shopping_commerce/storefront/app/(tabs)/profile.tsx
@@ -49,7 +49,7 @@ export default function ProfileScreen() {
           </Card>
         </ScreenSection>
 
-        <ScreenSection title="Loyalty">
+        <ScreenSection title="Loyalty" columns={{ base: 1, md: 3 }}>
           <MetricCard
             label="Points"
             value="4,280"

--- a/examples/shopping_commerce/storefront/app/_layout.tsx
+++ b/examples/shopping_commerce/storefront/app/_layout.tsx
@@ -1,9 +1,17 @@
-import { ZoraProvider } from '@ankhorage/zora';
+import { ZoraProvider, type ZoraTheme } from '@ankhorage/zora';
 import { Stack } from 'expo-router';
+
+const theme: ZoraTheme = {
+  id: 'storefront',
+  name: 'Studio Store',
+  appCategory: 'shopping_commerce',
+  primaryColor: '#ca8a04',
+  harmony: 'analogous',
+};
 
 export default function RootLayout() {
   return (
-    <ZoraProvider>
+    <ZoraProvider theme={theme}>
       <Stack screenOptions={{ headerShown: false }} />
     </ZoraProvider>
   );

--- a/examples/social_community/community-feed/app/_layout.tsx
+++ b/examples/social_community/community-feed/app/_layout.tsx
@@ -1,9 +1,17 @@
-import { ZoraProvider } from '@ankhorage/zora';
+import { ZoraProvider, type ZoraTheme } from '@ankhorage/zora';
 import { Stack } from 'expo-router';
+
+const theme: ZoraTheme = {
+  id: 'community-feed',
+  name: 'Community Feed',
+  appCategory: 'social_community',
+  primaryColor: '#4f46e5',
+  harmony: 'analogous',
+};
 
 export default function RootLayout() {
   return (
-    <ZoraProvider>
+    <ZoraProvider theme={theme}>
       <Stack screenOptions={{ headerShown: false }} />
     </ZoraProvider>
   );

--- a/examples/social_community/photo-social/app/_layout.tsx
+++ b/examples/social_community/photo-social/app/_layout.tsx
@@ -1,9 +1,17 @@
-import { ZoraProvider } from '@ankhorage/zora';
+import { ZoraProvider, type ZoraTheme } from '@ankhorage/zora';
 import { Stack } from 'expo-router';
+
+const theme: ZoraTheme = {
+  id: 'photo-social',
+  name: 'Photo Social',
+  appCategory: 'social_community',
+  primaryColor: '#db2777',
+  harmony: 'triadic',
+};
 
 export default function RootLayout() {
   return (
-    <ZoraProvider>
+    <ZoraProvider theme={theme}>
       <Stack screenOptions={{ headerShown: false }} />
     </ZoraProvider>
   );

--- a/examples/social_community/private-messaging/app/_layout.tsx
+++ b/examples/social_community/private-messaging/app/_layout.tsx
@@ -1,9 +1,17 @@
-import { ZoraProvider } from '@ankhorage/zora';
+import { ZoraProvider, type ZoraTheme } from '@ankhorage/zora';
 import { Stack } from 'expo-router';
+
+const theme: ZoraTheme = {
+  id: 'private-messaging',
+  name: 'Private Messaging',
+  appCategory: 'social_community',
+  primaryColor: '#2563eb',
+  harmony: 'splitComplementary',
+};
 
 export default function RootLayout() {
   return (
-    <ZoraProvider>
+    <ZoraProvider theme={theme}>
       <Stack screenOptions={{ headerShown: false }} />
     </ZoraProvider>
   );

--- a/examples/social_community/visual-discovery/app/_layout.tsx
+++ b/examples/social_community/visual-discovery/app/_layout.tsx
@@ -1,9 +1,17 @@
-import { ZoraProvider } from '@ankhorage/zora';
+import { ZoraProvider, type ZoraTheme } from '@ankhorage/zora';
 import { Stack } from 'expo-router';
+
+const theme: ZoraTheme = {
+  id: 'visual-discovery',
+  name: 'Visual Discovery',
+  appCategory: 'social_community',
+  primaryColor: '#9333ea',
+  harmony: 'tetradic',
+};
 
 export default function RootLayout() {
   return (
-    <ZoraProvider>
+    <ZoraProvider theme={theme}>
       <Stack screenOptions={{ headerShown: false }} />
     </ZoraProvider>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,7 @@ export type { InspectorFieldProps } from './patterns/inspector-field';
 export { InspectorField } from './patterns/inspector-field';
 export type {
   ListChildrenProps,
+  ListGridProps,
   ListItemsProps,
   ListProps,
   ListRowProps,

--- a/src/layout/screen-section/ScreenSection.tsx
+++ b/src/layout/screen-section/ScreenSection.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 
-import { Stack } from '../../foundation';
+import { Grid, Stack } from '../../foundation';
 import { SectionHeader } from '../../patterns/section-header';
 import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
 import type { ScreenSectionProps } from './types';
+
+function hasGridLayout({ columns, minItemWidth }: ScreenSectionProps): boolean {
+  return columns !== undefined || minItemWidth !== undefined;
+}
 
 function ScreenSectionInner({
   themeId: _themeId,
@@ -12,12 +16,23 @@ function ScreenSectionInner({
   description,
   actions,
   children,
+  columns,
+  gap = 'm',
+  minItemWidth,
   testID,
 }: ScreenSectionProps) {
+  const content = hasGridLayout({ columns, minItemWidth }) ? (
+    <Grid cols={columns ?? { base: 1, md: 2, xl: 3 }} gap={gap} minItemWidth={minItemWidth}>
+      {children}
+    </Grid>
+  ) : (
+    children
+  );
+
   return (
     <Stack gap="m" testID={testID}>
       {title ? <SectionHeader actions={actions} description={description} title={title} /> : null}
-      {children}
+      {content}
     </Stack>
   );
 }

--- a/src/layout/screen-section/types.ts
+++ b/src/layout/screen-section/types.ts
@@ -1,5 +1,6 @@
 import type React from 'react';
 
+import type { GridProps } from '../../foundation';
 import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 
 export interface ScreenSectionProps extends ZoraBaseProps {
@@ -7,4 +8,7 @@ export interface ScreenSectionProps extends ZoraBaseProps {
   description?: React.ReactNode;
   actions?: React.ReactNode;
   children?: React.ReactNode;
+  columns?: GridProps['cols'];
+  gap?: GridProps['gap'];
+  minItemWidth?: GridProps['minItemWidth'];
 }

--- a/src/patterns/list/List.tsx
+++ b/src/patterns/list/List.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Divider, Spacer, Stack } from '../../foundation';
+import { Divider, Grid, Spacer, Stack } from '../../foundation';
 import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
 import { ListRow } from './ListRow';
 import { resolveListSeparator } from './resolveListSeparator';
@@ -26,6 +26,14 @@ function resolveRowCompact({
   return item.compact ?? compact ?? false;
 }
 
+function resolveCardGridColumns(cols: ListItemsProps['columns']): ListItemsProps['columns'] {
+  return cols ?? { base: 1, md: 2, xl: 3 };
+}
+
+function resolveCardGridGap(gap: ListItemsProps['gap']): ListItemsProps['gap'] {
+  return gap ?? 's';
+}
+
 function ListItemsInner({
   themeId: _themeId,
   mode: _mode,
@@ -33,7 +41,30 @@ function ListItemsInner({
   items,
   rowVariant = 'divider',
   compact,
+  columns,
+  gap,
+  minItemWidth,
 }: ListItemsProps) {
+  if (rowVariant === 'card') {
+    return (
+      <Grid
+        cols={resolveCardGridColumns(columns)}
+        gap={resolveCardGridGap(gap)}
+        minItemWidth={minItemWidth}
+        testID={testID}
+      >
+        {items.map((item, index) => (
+          <ListRow
+            {...item}
+            compact={resolveRowCompact({ item, compact })}
+            key={`${index}`}
+            variant={resolveRowVariant({ item, defaultVariant: rowVariant })}
+          />
+        ))}
+      </Grid>
+    );
+  }
+
   return (
     <Stack gap="none" testID={testID}>
       {items.map((item, index) => {

--- a/src/patterns/list/List.tsx
+++ b/src/patterns/list/List.tsx
@@ -34,6 +34,16 @@ function resolveCardGridGap(gap: ListItemsProps['gap']): ListItemsProps['gap'] {
   return gap ?? 's';
 }
 
+function shouldRenderGrid({
+  items,
+  rowVariant,
+}: {
+  items: readonly ListRowProps[];
+  rowVariant: ListRowVariant;
+}): boolean {
+  return items.every((item) => resolveRowVariant({ item, defaultVariant: rowVariant }) === 'card');
+}
+
 function ListItemsInner({
   themeId: _themeId,
   mode: _mode,
@@ -45,7 +55,7 @@ function ListItemsInner({
   gap,
   minItemWidth,
 }: ListItemsProps) {
-  if (rowVariant === 'card') {
+  if (shouldRenderGrid({ items, rowVariant })) {
     return (
       <Grid
         cols={resolveCardGridColumns(columns)}

--- a/src/patterns/list/List.tsx
+++ b/src/patterns/list/List.tsx
@@ -6,6 +6,8 @@ import { ListRow } from './ListRow';
 import { resolveListSeparator } from './resolveListSeparator';
 import type { ListItemsProps, ListProps, ListRowProps, ListRowVariant } from './types';
 
+type ListGridColumns = NonNullable<ListItemsProps['columns']>;
+
 function resolveRowVariant({
   item,
   defaultVariant,
@@ -26,7 +28,7 @@ function resolveRowCompact({
   return item.compact ?? compact ?? false;
 }
 
-function resolveCardGridColumns(cols: ListItemsProps['columns']): ListItemsProps['columns'] {
+function resolveCardGridColumns(cols: ListItemsProps['columns']): ListGridColumns {
   return cols ?? { base: 1, md: 2, xl: 3 };
 }
 

--- a/src/patterns/list/index.ts
+++ b/src/patterns/list/index.ts
@@ -3,6 +3,7 @@ export { ListRow } from './ListRow';
 export { ListSection } from './ListSection';
 export type {
   ListChildrenProps,
+  ListGridProps,
   ListItemsProps,
   ListProps,
   ListRowProps,

--- a/src/patterns/list/types.ts
+++ b/src/patterns/list/types.ts
@@ -1,8 +1,15 @@
 import type React from 'react';
 
+import type { GridProps } from '../../foundation';
 import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 
 export type ListRowVariant = 'divider' | 'card';
+
+export interface ListGridProps {
+  columns?: GridProps['cols'];
+  gap?: GridProps['gap'];
+  minItemWidth?: GridProps['minItemWidth'];
+}
 
 interface ListRowBaseProps extends ZoraBaseProps {
   title: React.ReactNode;
@@ -34,7 +41,7 @@ interface ListRowStaticProps {
 export type ListRowProps = ListRowBaseProps &
   (ListRowPressableProps | ListRowActionProps | ListRowStaticProps);
 
-export interface ListItemsProps extends ZoraBaseProps {
+export interface ListItemsProps extends ZoraBaseProps, ListGridProps {
   items: readonly ListRowProps[];
   rowVariant?: ListRowVariant;
   compact?: boolean;
@@ -46,7 +53,7 @@ export interface ListChildrenProps extends ZoraBaseProps {
 
 export type ListProps = ListItemsProps | ListChildrenProps;
 
-interface ListSectionItemsProps extends ZoraBaseProps {
+interface ListSectionItemsProps extends ZoraBaseProps, ListGridProps {
   title?: React.ReactNode;
   description?: React.ReactNode;
   eyebrow?: React.ReactNode;


### PR DESCRIPTION
## Summary

Implements #162.

- adds responsive grid behavior to `List` and `ListSection` for card-style rows
- adds optional responsive `columns`, `gap`, and `minItemWidth` support to `ScreenSection`
- applies responsive `ScreenSection` columns to metric-heavy realistic example screens
- gives each realistic example app a distinct app-level `ZoraTheme` seed
- adds a visual QA checklist for realistic examples
- adds a changeset

## Notes

The implementation keeps density improvements in ZORA APIs instead of local example layout wrappers. Examples use public ZORA props such as `columns`, not `StyleSheet` or Surface imports.

## Verification

Run locally:

```bash
bun run build
bun run lint:fix
bun run test
```

Visual QA:

- inspect realistic examples on mobile width and desktop/web width
- verify card-row list sections become denser on wider screens
- verify metric overview sections render as columns on wider screens
- verify each realistic app has a distinct theme color/feel

## Related

Closes #162