### PR TITLE
04 Add component metadata for props, events, and emitted payloads

### DIFF
--- a/.changeset/component-event-metadata.md
+++ b/.changeset/component-event-metadata.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/zora": minor
+---
+
+Add component event metadata types and initial event descriptors for form submit, button press, and collection item press events.

--- a/.changeset/component-event-metadata.md
+++ b/.changeset/component-event-metadata.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/zora": minor
+'@ankhorage/zora': minor
 ---
 
 Add component event metadata types and initial event descriptors for form submit, button press, and collection item press events.

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@ankhorage/zora",
       "dependencies": {
         "@ankhorage/color-theory": "^0.0.7",
-        "@ankhorage/contracts": "^1.3.1",
+        "@ankhorage/contracts": "^1.6.0",
         "@ankhorage/surface": "^2.0.0",
       },
       "devDependencies": {
@@ -38,7 +38,7 @@
   "packages": {
     "@ankhorage/color-theory": ["@ankhorage/color-theory@0.0.7", "", { "dependencies": { "culori": "^4.0.2" } }, "sha512-fcdJZMmhfbvc9Yhz5vjTolmWYAaCsUaUOq4/P6YDZLHhXer8Mv8y0LaOhWgaXcwq48nrxILGUMOxOl48tRhTmA=="],
 
-    "@ankhorage/contracts": ["@ankhorage/contracts@1.3.1", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7" } }, "sha512-Wc0cEKKA07ChaLb53WLJto7MlBV/8jl+DOhuZNsWxrtQj6daxD5KTe06zc8fXgtvDCSzZj+Iz8mRRK6LXvzR1A=="],
+    "@ankhorage/contracts": ["@ankhorage/contracts@1.6.0", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7" } }, "sha512-N+a2tLFTTIrDGxHxCcHHuPNvbgi/rhuopZP7qIuLuUgcEj7efepnPBsQVdgsT25abMljiuSwI+1xKFJ9eDrpJw=="],
 
     "@ankhorage/devtools": ["@ankhorage/devtools@1.0.6", "", { "dependencies": { "@eslint/js": "^10.0.1", "eslint": "^10.2.0", "eslint-config-prettier": "^10.1.8", "eslint-plugin-import": "^2.32.0", "eslint-plugin-prettier": "^5.5.5", "eslint-plugin-simple-import-sort": "^12.1.1", "eslint-plugin-unused-imports": "^4.4.1", "knip": "^6.12.2", "prettier": "^3.8.1", "typescript-eslint": "^8.24.0" }, "bin": { "ankhorage-eslint": "dist/eslint-cli.js", "ankhorage-knip": "dist/knip-cli.js", "ankhorage-prettier": "dist/prettier-cli.js" } }, "sha512-QXvpJ3uvr3xcl/smjv0yMimtGRCt/dPs0lVdHYMAXg06u1HsZmoKhRyxdFX8OXcCv9RnfPNheUkjAbOrs0eeaQ=="],
 
@@ -1613,6 +1613,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@ankhorage/surface/@ankhorage/contracts": ["@ankhorage/contracts@1.3.1", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7" } }, "sha512-Wc0cEKKA07ChaLb53WLJto7MlBV/8jl+DOhuZNsWxrtQj6daxD5KTe06zc8fXgtvDCSzZj+Iz8mRRK6LXvzR1A=="],
 
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@ankhorage/color-theory": "^0.0.7",
-    "@ankhorage/contracts": "^1.3.1",
+    "@ankhorage/contracts": "^1.6.0",
     "@ankhorage/surface": "^2.0.0"
   },
   "files": [

--- a/src/components/button/meta.ts
+++ b/src/components/button/meta.ts
@@ -15,6 +15,14 @@ export const buttonMeta = {
       size: 'm',
     },
   },
+  events: {
+    press: {
+      label: 'Press',
+      eventType: 'button.press',
+      description: 'Emitted when the button action runs.',
+      payloadFields: [],
+    },
+  },
   props: {
     children: {
       type: 'string',

--- a/src/components/form/meta.ts
+++ b/src/components/form/meta.ts
@@ -6,6 +6,21 @@ export const formMeta = {
   directManifestNode: false,
   allowedChildren: [],
   note: 'Form orchestration component; not represented as a manifest node in v1.',
+  events: {
+    submit: {
+      label: 'Submit',
+      eventType: 'form.submit',
+      description: 'Emitted when the form submits its current values.',
+      payloadFields: [
+        {
+          path: 'payload.values',
+          type: 'record',
+          label: 'Values',
+          description: 'Submitted form values keyed by field name.',
+        },
+      ],
+    },
+  },
   props: {},
 } as const satisfies ZoraComponentMeta;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,6 +157,10 @@ export { TopbarLayout } from './layout/topbar-layout';
 export type {
   ZoraComponentBlueprint,
   ZoraComponentCategory,
+  ZoraComponentEventMeta,
+  ZoraComponentEventPayloadFieldMeta,
+  ZoraComponentEventPayloadFieldType,
+  ZoraComponentEventPayloadKind,
   ZoraComponentI18nMeta,
   ZoraComponentMeta,
   ZoraComponentMetaRegistry,

--- a/src/metadata/componentMeta.test.ts
+++ b/src/metadata/componentMeta.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
 
 import { ZORA_COMPONENT_META } from './componentMeta';
+import type { ZoraComponentEventPayloadKind } from './types';
 
 const ROOT = process.cwd();
 const SRC_ROOT = join(ROOT, 'src');
@@ -62,6 +63,12 @@ describe('ZORA_COMPONENT_META public API', () => {
     const indexSource = readSource(INDEX_PATH);
     expect(indexSource).toContain('ZORA_COMPONENT_META');
   });
+
+  test('src/index.ts re-exports component event metadata types', () => {
+    const indexSource = readSource(INDEX_PATH);
+    expect(indexSource).toContain('ZoraComponentEventMeta');
+    expect(indexSource).toContain('ZoraComponentEventPayloadKind');
+  });
 });
 
 describe('ZORA_COMPONENT_META registry coverage', () => {
@@ -105,6 +112,35 @@ describe('ZORA_COMPONENT_META registry coverage', () => {
       expect(themeValueExports.has(providerExport)).toBe(true);
       expect(Object.prototype.hasOwnProperty.call(ZORA_COMPONENT_META, providerExport)).toBe(false);
     }
+  });
+});
+
+describe('ZORA_COMPONENT_META event metadata', () => {
+  test('declares form submit metadata', () => {
+    const event = ZORA_COMPONENT_META.Form.events?.submit;
+    const eventType: ZoraComponentEventPayloadKind = event?.eventType ?? 'form.submit';
+
+    expect(eventType).toBe('form.submit');
+    expect(event?.payloadFields?.map((field) => field.path)).toEqual(['payload.values']);
+  });
+
+  test('declares button event metadata', () => {
+    const event = ZORA_COMPONENT_META.Button.events?.press;
+    const eventType: ZoraComponentEventPayloadKind = event?.eventType ?? 'button.press';
+
+    expect(eventType).toBe('button.press');
+    expect(event?.payloadFields).toEqual([]);
+  });
+
+  test('declares collection item metadata for list rows', () => {
+    const event = ZORA_COMPONENT_META.ListRow.events?.itemPress;
+    const eventType: ZoraComponentEventPayloadKind = event?.eventType ?? 'collection.itemPress';
+
+    expect(eventType).toBe('collection.itemPress');
+    expect(event?.payloadFields?.map((field) => field.path)).toEqual([
+      'payload.itemId',
+      'payload.item',
+    ]);
   });
 });
 

--- a/src/metadata/index.ts
+++ b/src/metadata/index.ts
@@ -2,6 +2,10 @@ export { ZORA_COMPONENT_META } from './componentMeta';
 export type {
   ZoraComponentBlueprint,
   ZoraComponentCategory,
+  ZoraComponentEventMeta,
+  ZoraComponentEventPayloadFieldMeta,
+  ZoraComponentEventPayloadFieldType,
+  ZoraComponentEventPayloadKind,
   ZoraComponentI18nMeta,
   ZoraComponentMeta,
   ZoraComponentMetaRegistry,

--- a/src/metadata/types.ts
+++ b/src/metadata/types.ts
@@ -1,3 +1,5 @@
+import type { ComponentEventDtoKind } from '@ankhorage/contracts';
+
 export type ZoraComponentCategory = 'foundation' | 'component' | 'pattern' | 'layout';
 
 export type ZoraComponentPropType =
@@ -53,6 +55,30 @@ export interface ZoraComponentI18nMeta {
   }[];
 }
 
+export type ZoraComponentEventPayloadKind = ComponentEventDtoKind | (string & {});
+
+export type ZoraComponentEventPayloadFieldType =
+  | 'boolean'
+  | 'number'
+  | 'object'
+  | 'record'
+  | 'string'
+  | 'unknown';
+
+export interface ZoraComponentEventPayloadFieldMeta {
+  readonly path: string;
+  readonly type: ZoraComponentEventPayloadFieldType;
+  readonly label?: string;
+  readonly description?: string;
+}
+
+export interface ZoraComponentEventMeta {
+  readonly label: string;
+  readonly eventType: ZoraComponentEventPayloadKind;
+  readonly description?: string;
+  readonly payloadFields?: readonly ZoraComponentEventPayloadFieldMeta[];
+}
+
 export interface ZoraComponentSlotMeta {
   label?: string;
   allowedChildren?: readonly string[];
@@ -65,6 +91,7 @@ export interface ZoraComponentMeta {
   directManifestNode: boolean;
   allowedChildren: readonly string[];
   blueprint?: ZoraComponentBlueprint;
+  events?: Readonly<Record<string, ZoraComponentEventMeta>>;
   i18n?: ZoraComponentI18nMeta;
   slots?: Readonly<Record<string, ZoraComponentSlotMeta>>;
   note?: string;

--- a/src/patterns/list/meta.ts
+++ b/src/patterns/list/meta.ts
@@ -17,6 +17,25 @@ export const listRowMeta = {
   directManifestNode: false,
   allowedChildren: [],
   note: LIST_NOTE,
+  events: {
+    itemPress: {
+      label: 'Item press',
+      eventType: 'collection.itemPress',
+      description: 'Emitted when a collection item row is selected.',
+      payloadFields: [
+        {
+          path: 'payload.itemId',
+          type: 'string',
+          label: 'Item ID',
+        },
+        {
+          path: 'payload.item',
+          type: 'record',
+          label: 'Item',
+        },
+      ],
+    },
+  },
   props: {},
 } as const satisfies ZoraComponentMeta;
 


### PR DESCRIPTION
## Summary

- updates `@ankhorage/contracts` dependency to `^1.6.0`
- extends the existing ZORA metadata schema with component event metadata
- ties event metadata kinds to the canonical `ComponentEventDtoKind` from `@ankhorage/contracts`
- adds initial event descriptors for:
  - `Form.submit -> form.submit`
  - `Button.press -> button.press`
  - `ListRow.itemPress -> collection.itemPress`
- exports the new event metadata types from the metadata module and root barrel
- adds registry tests for public metadata exports and event descriptors
- adds a changeset

Closes #186.

## Notes

This is ZORA-only. It does not touch `@ankhorage/surface`, does not add persistence/state behavior to components, and does not add runtime action execution.

## Verification

Please run locally:

```bash
bun install
bun run build
bun run lint:fix
bun run test
bun run knip
```

I could not run local verification from this environment.