### PR TITLE
Remove AppShell style props

### DIFF
--- a/.changeset/remove-appshell-style-props.md
+++ b/.changeset/remove-appshell-style-props.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/zora": minor
+---
+
+Remove raw `style` and `bodyStyle` escape hatches from `AppShell`. AppShell remains a structural app frame; layout customization should happen through composed ZORA primitives instead of arbitrary root/body style overrides.

--- a/.changeset/remove-appshell-style-props.md
+++ b/.changeset/remove-appshell-style-props.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/zora": minor
+'@ankhorage/zora': minor
 ---
 
 Remove raw `style` and `bodyStyle` escape hatches from `AppShell`. AppShell remains a structural app frame; layout customization should happen through composed ZORA primitives instead of arbitrary root/body style overrides.

--- a/README.md
+++ b/README.md
@@ -1390,8 +1390,6 @@ ZORA props:
 | `header`    | `React.ReactNode`      | -       | Optional top section (e.g. toolbar or navigation).                                   |
 | `footer`    | `React.ReactNode`      | -       | Optional bottom section (e.g. tab bar or actions).                                   |
 | `overlay`   | `React.ReactNode`      | -       | Optional overlay layer rendered above content (e.g. drawer, modal, floating panels). |
-| `style`     | `StyleProp<ViewStyle>` | -       | Style applied to the root container.                                                 |
-| `bodyStyle` | `StyleProp<ViewStyle>` | -       | Style applied to the main content container.                                         |
 | `testID`    | `string`               | -       | Forwarded to the root Surface container.                                             |
 
 Inherited props:

--- a/src/layout/app-shell/AppShell.test.ts
+++ b/src/layout/app-shell/AppShell.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+const APP_SHELL_DIR = import.meta.dir;
+
+function readAppShellFile(fileName: string): string {
+  return readFileSync(join(APP_SHELL_DIR, fileName), 'utf8');
+}
+
+describe('AppShell public API', () => {
+  test('does not expose raw style escape hatches', () => {
+    const typesSource = readAppShellFile('types.ts');
+    const implementationSource = readAppShellFile('AppShell.tsx');
+
+    expect(typesSource).not.toContain('StyleProp');
+    expect(typesSource).not.toContain('ViewStyle');
+    expect(typesSource).not.toMatch(/\bstyle\??:/);
+    expect(typesSource).not.toMatch(/\bbodyStyle\??:/);
+    expect(implementationSource).not.toMatch(/\bbodyStyle\b/);
+    expect(implementationSource).not.toMatch(/\bstyle,\s*$/m);
+  });
+});

--- a/src/layout/app-shell/AppShell.tsx
+++ b/src/layout/app-shell/AppShell.tsx
@@ -12,16 +12,14 @@ function AppShellInner({
   header,
   footer,
   overlay,
-  style,
-  bodyStyle,
   testID,
 }: AppShellProps) {
   return (
-    <Box bg="background" flex={1} style={style} testID={testID}>
+    <Box bg="background" flex={1} testID={testID}>
       <View style={styles.root}>
         {header ? <View style={styles.slot}>{header}</View> : null}
 
-        <View style={[styles.body, bodyStyle]}>{children}</View>
+        <View style={styles.body}>{children}</View>
 
         {footer ? <View style={styles.slot}>{footer}</View> : null}
 

--- a/src/layout/app-shell/types.ts
+++ b/src/layout/app-shell/types.ts
@@ -1,5 +1,4 @@
 import type React from 'react';
-import type { StyleProp, ViewStyle } from 'react-native';
 
 import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 
@@ -8,6 +7,4 @@ export interface AppShellProps extends ZoraBaseProps {
   header?: React.ReactNode;
   footer?: React.ReactNode;
   overlay?: React.ReactNode;
-  style?: StyleProp<ViewStyle>;
-  bodyStyle?: StyleProp<ViewStyle>;
 }


### PR DESCRIPTION
## Summary

- remove `style` and `bodyStyle` from `AppShellProps`
- stop forwarding root/body style arrays in `AppShell`
- add a focused AppShell public API guard test so raw style escape hatches do not creep back in
- add a changeset for the public API change

## Context

This is the first scoped slice for #191.

ZORA should expose semantic/tokenized layout intent instead of raw style escape hatches. `AppShell` is the explicit public offender from the issue body, so this PR starts there and keeps Surface as the lower-level escape hatch.

## Notes

- No replacement props are added in this PR because current `AppShell` usage in the repo does not depend on `style` or `bodyStyle`.
- README still documents `style` and `bodyStyle`; I left it untouched to avoid another risky full-file connector rewrite. Manual README follow-up should remove those rows from the AppShell props table.
- This does not audit/remove every internal implementation `style` object. Internal React Native styles remain fine; this PR removes the public API escape hatch.
- Branch is currently behind `main` by one commit and may need update before final verification.

## Verification

Not run in this environment. Recommended local checks:

```bash
bun run build
bun run lint:fix
bun run test
bun run knip
```

Closes #191