### PR TITLE
fix: align semantic color props in metadata and examples

### DIFF
--- a/.changeset/notice-color-metadata.md
+++ b/.changeset/notice-color-metadata.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Align Notice metadata with its public color prop.

--- a/examples/expo-showcase/app/chats.tsx
+++ b/examples/expo-showcase/app/chats.tsx
@@ -22,7 +22,7 @@ export function ChatsPage() {
         <Stack gap="none">
           <ChatListItem
             accessibilityLabel="Ada Lovelace, unread, 3 new messages, Can you review the new PostCard API?, 2 minutes ago"
-            avatar={{ name: 'Ada Lovelace', tone: 'primary' }}
+            avatar={{ name: 'Ada Lovelace', color: 'primary' }}
             preview="Can you review the new PostCard API?"
             timestamp="2m"
             title="Ada Lovelace"
@@ -32,7 +32,7 @@ export function ChatsPage() {
           />
 
           <ChatListItem
-            avatar={{ name: 'Grace Hopper', tone: 'success' }}
+            avatar={{ name: 'Grace Hopper', color: 'success' }}
             preview="The build is green."
             timestamp="1h"
             title="Grace Hopper"
@@ -40,7 +40,7 @@ export function ChatsPage() {
           />
 
           <ChatListItem
-            avatar={{ initials: 'CI', label: 'Build system', tone: 'neutral' }}
+            avatar={{ initials: 'CI', label: 'Build system', color: 'neutral' }}
             compact
             meta="Release automation"
             preview="Version packages completed for @ankhorage/zora."
@@ -50,7 +50,7 @@ export function ChatsPage() {
           />
 
           <ChatListItem
-            avatar={{ name: 'Maya Chen', tone: 'warning' }}
+            avatar={{ name: 'Maya Chen', color: 'warning' }}
             preview="Let's revisit the mobile layout before the next pass."
             selected
             timestamp="Yesterday"
@@ -65,7 +65,7 @@ export function ChatsPage() {
           />
 
           <ChatListItem
-            avatar={{ name: 'Archived thread', tone: 'neutral' }}
+            avatar={{ name: 'Archived thread', color: 'neutral' }}
             disabled
             meta="Archived"
             preview="This row shows the disabled state."
@@ -83,7 +83,7 @@ export function ChatsPage() {
           <MessageBubble
             author={{
               name: 'Ada Lovelace',
-              avatar: { name: 'Ada Lovelace', tone: 'primary' },
+              avatar: { name: 'Ada Lovelace', color: 'primary' },
             }}
             direction="incoming"
             text="Can you review the new ChatListItem API?"
@@ -104,7 +104,7 @@ export function ChatsPage() {
           <MessageBubble
             author={{
               name: 'Grace Hopper',
-              avatar: { name: 'Grace Hopper', tone: 'success' },
+              avatar: { name: 'Grace Hopper', color: 'success' },
             }}
             direction="incoming"
             meta="Edited"

--- a/examples/expo-showcase/app/components.tsx
+++ b/examples/expo-showcase/app/components.tsx
@@ -444,10 +444,10 @@ export function ComponentsPage() {
               <AvatarGroup
                 items={[
                   { id: '1', name: 'Fabio Gartenmann' },
-                  { id: '2', name: 'Ada Lovelace', tone: 'primary' },
-                  { id: '3', name: 'Grace Hopper', tone: 'success' },
-                  { id: '4', name: 'Linus Torvalds', tone: 'warning' },
-                  { id: '5', name: 'Lynn Conway', tone: 'danger' },
+                  { id: '2', name: 'Ada Lovelace', color: 'primary' },
+                  { id: '3', name: 'Grace Hopper', color: 'success' },
+                  { id: '4', name: 'Linus Torvalds', color: 'warning' },
+                  { id: '5', name: 'Lynn Conway', color: 'danger' },
                 ]}
               />
             </Stack>

--- a/examples/expo-showcase/app/posts.tsx
+++ b/examples/expo-showcase/app/posts.tsx
@@ -17,7 +17,7 @@ export function PostsPage() {
             author={{
               name: 'Ada Lovelace',
               subtitle: '@ada · 2h',
-              avatar: { name: 'Ada Lovelace', tone: 'primary' },
+              avatar: { name: 'Ada Lovelace', color: 'primary' },
             }}
             headerAction={
               <IconButton
@@ -50,7 +50,7 @@ export function PostsPage() {
                 author: {
                   name: 'Grace Hopper',
                   subtitle: '1h',
-                  avatar: { name: 'Grace Hopper', tone: 'success' },
+                  avatar: { name: 'Grace Hopper', color: 'success' },
                 },
                 text: 'The boundary between card anatomy and feed rendering feels right.',
               },
@@ -63,7 +63,7 @@ export function PostsPage() {
             author={{
               name: 'Build system',
               subtitle: 'Today · release notes',
-              avatar: { initials: 'CI', label: 'Build system', tone: 'neutral' },
+              avatar: { initials: 'CI', label: 'Build system', color: 'neutral' },
             }}
             text="PostCard also supports compact density for system updates and notification-style content."
             actions={[
@@ -85,7 +85,7 @@ export function PostsPage() {
             author={{
               name: 'Maya Chen',
               subtitle: 'Product design · Yesterday',
-              avatar: { name: 'Maya Chen', tone: 'warning' },
+              avatar: { name: 'Maya Chen', color: 'warning' },
             }}
             text="Custom media slots stay possible without making PostCard own uploads, storage, or provider logic."
             media={{

--- a/examples/expo-showcase/bun.lock
+++ b/examples/expo-showcase/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "zora-expo-showcase",
       "dependencies": {
-        "@ankhorage/zora": "^1.4.12",
+        "@ankhorage/zora": "^2.4.2",
         "@expo/vector-icons": "^15.0.3",
         "@react-native-picker/picker": "2.11.1",
         "expo": "~54.0.34",
@@ -28,11 +28,11 @@
 
     "@ankhorage/color-theory": ["@ankhorage/color-theory@0.0.7", "", { "dependencies": { "culori": "^4.0.2" } }, "sha512-fcdJZMmhfbvc9Yhz5vjTolmWYAaCsUaUOq4/P6YDZLHhXer8Mv8y0LaOhWgaXcwq48nrxILGUMOxOl48tRhTmA=="],
 
-    "@ankhorage/contracts": ["@ankhorage/contracts@1.3.1", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7" } }, "sha512-Wc0cEKKA07ChaLb53WLJto7MlBV/8jl+DOhuZNsWxrtQj6daxD5KTe06zc8fXgtvDCSzZj+Iz8mRRK6LXvzR1A=="],
+    "@ankhorage/contracts": ["@ankhorage/contracts@1.8.0", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7" } }, "sha512-sDo5cBpQjyqUPGTjVht9jwqJRre9IjBo1isO5g0TalQojk/BPbjEoZAEgnIpzteYXVmWkD92KfAKB1MYJp/2kw=="],
 
-    "@ankhorage/surface": ["@ankhorage/surface@1.4.0", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7", "@ankhorage/contracts": "^1.3.1" }, "peerDependencies": { "@expo/vector-icons": ">=14.0.0", "expo-font": "^55.0.6", "react": ">=18.2.0", "react-native": ">=0.72.0", "react-native-safe-area-context": "^5.0.0" }, "optionalPeers": ["@expo/vector-icons", "expo-font"] }, "sha512-Ygf46XqZ+vN2n+ye02UeFAY3UjcATGuzfL7y/5VuQouzsXMKezQDyEATxpPtjyQG8OJwamiMbQfiuR8X9Lob8A=="],
+    "@ankhorage/surface": ["@ankhorage/surface@2.0.2", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7", "@ankhorage/contracts": "^1.7.0" }, "peerDependencies": { "@expo/vector-icons": ">=14.0.0", "expo-font": "^55.0.6", "react": ">=18.2.0", "react-native": ">=0.72.0", "react-native-safe-area-context": "^5.0.0" }, "optionalPeers": ["@expo/vector-icons", "expo-font"] }, "sha512-mqWxud3bFEezlrtYselveqrhEI9olgGMNHv35iI/pvzZP+oPqIwKSl5JzV7CTrbzp+YhHZVNzAzYEMtdhiD5QA=="],
 
-    "@ankhorage/zora": ["@ankhorage/zora@1.4.12", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7", "@ankhorage/contracts": "^1.3.1", "@ankhorage/surface": "^1.3.1" }, "peerDependencies": { "@expo/vector-icons": ">=14.0.0", "@react-native-picker/picker": ">=2.0.0", "expo-font": "^55.0.6", "react": ">=18.2.0", "react-native": ">=0.72.0" }, "optionalPeers": ["@expo/vector-icons", "@react-native-picker/picker", "expo-font"] }, "sha512-mldSQSTxbdqkvdyKMnF5ufav5iI47uqIgxpeViGjbye/seJxm1UI/YBnAEn0CaF8LZ9hOe8jBZXA8ZRXN21zAQ=="],
+    "@ankhorage/zora": ["@ankhorage/zora@2.4.2", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7", "@ankhorage/contracts": "^1.7.0", "@ankhorage/surface": "^2.0.0" }, "peerDependencies": { "@expo/vector-icons": ">=14.0.0", "@react-native-picker/picker": ">=2.0.0", "expo-font": "^55.0.6", "react": ">=18.2.0", "react-native": ">=0.72.0" }, "optionalPeers": ["@expo/vector-icons", "@react-native-picker/picker", "expo-font"] }, "sha512-0c2KABUiennnTKlvtnoikdimKHIdZMl3ILY8zpFRjvfI+oXhT9Uiz29UqB5i8ljQOLN/VjymQmkoTRwHimk7ZQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 

--- a/examples/expo-showcase/package.json
+++ b/examples/expo-showcase/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ankhorage/zora": "^1.4.12",
+    "@ankhorage/zora": "^2.4.2",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-picker/picker": "2.11.1",
     "expo": "~54.0.34",

--- a/examples/food_drink/restaurant/app/(tabs)/index.tsx
+++ b/examples/food_drink/restaurant/app/(tabs)/index.tsx
@@ -18,7 +18,7 @@ export default function HomeScreen() {
         <ScreenSection
           title="Tonight's feature"
           description="Restaurant home content composed from ZORA media cards and badges."
-          actions={<Badge tone="success">Open now</Badge>}
+          actions={<Badge color="success">Open now</Badge>}
         >
           <MediaCard
             title="Spring tasting menu"
@@ -27,13 +27,13 @@ export default function HomeScreen() {
               uri: 'https://images.unsplash.com/photo-1414235077428-338989a2e8c0?auto=format&fit=crop&w=1200&q=80',
             }}
             imageLabel="Restaurant table with plated dinner"
-            badges={<Badge tone="primary">Chef's pick</Badge>}
+            badges={<Badge color="primary">Chef's pick</Badge>}
             footer={
               <AvatarGroup
                 items={[
-                  { id: 'chef', name: 'Elena Rossi', tone: 'primary' },
-                  { id: 'host', name: 'Marco Frei', tone: 'success' },
-                  { id: 'sommelier', name: 'Lina Keller', tone: 'warning' },
+                  { id: 'chef', name: 'Elena Rossi', color: 'primary' },
+                  { id: 'host', name: 'Marco Frei', color: 'success' },
+                  { id: 'sommelier', name: 'Lina Keller', color: 'warning' },
                 ]}
               />
             }
@@ -44,9 +44,9 @@ export default function HomeScreen() {
           <Notice
             title="Reservations available"
             description="Tables are open from 18:00. Booking persistence is intentionally outside this static UI example."
-            tone="primary"
+            color="primary"
           />
-          <Text tone="muted">
+          <Text emphasis="muted">
             A dedicated RestaurantHero or MenuFeature pattern would make this app stronger later.
           </Text>
         </ScreenSection>

--- a/examples/food_drink/restaurant/app/(tabs)/menu.tsx
+++ b/examples/food_drink/restaurant/app/(tabs)/menu.tsx
@@ -57,7 +57,7 @@ export default function MenuScreen() {
               uri: 'https://images.unsplash.com/photo-1551183053-bf91a1d81141?auto=format&fit=crop&w=1200&q=80',
             }}
             imageLabel="Fresh pasta and burrata dish"
-            badges={<Badge tone="success">Vegetarian</Badge>}
+            badges={<Badge color="success">Vegetarian</Badge>}
           />
         </ScreenSection>
 
@@ -66,7 +66,7 @@ export default function MenuScreen() {
           description="Structured menu rows until ZORA has dedicated menu item cards."
           items={menuRows}
         />
-        <Text tone="muted">
+        <Text emphasis="muted">
           Restaurant examples reveal a future need for MenuItem, DietaryBadge, and PriceRow
           patterns.
         </Text>

--- a/examples/food_drink/restaurant/app/(tabs)/orders.tsx
+++ b/examples/food_drink/restaurant/app/(tabs)/orders.tsx
@@ -34,7 +34,7 @@ export default function OrdersScreen() {
             label="Ready soon"
             value="19:10"
             delta="Takeaway"
-            deltaTone="primary"
+            deltaColor="primary"
             description="Kitchen estimate"
           />
           <MetricCard label="Vouchers" value="1" description="Email delivery" />
@@ -50,7 +50,7 @@ export default function OrdersScreen() {
           <Notice
             title="No kitchen integration"
             description="Kitchen display, payment, voucher fulfillment, and live order status belong in later app/backend examples."
-            tone="primary"
+            color="primary"
           />
         </ScreenSection>
       </Screen>

--- a/examples/food_drink/restaurant/app/(tabs)/profile.tsx
+++ b/examples/food_drink/restaurant/app/(tabs)/profile.tsx
@@ -32,9 +32,9 @@ export default function ProfileScreen() {
           <Card
             title="Nora Frei"
             description="Regular guest · Zürich · last visit two weeks ago"
-            actions={<Badge tone="success">VIP</Badge>}
+            actions={<Badge color="success">VIP</Badge>}
           >
-            <Text tone="muted">
+            <Text emphasis="muted">
               Prefers early dinner slots, vegetarian tasting menus, and quiet tables.
             </Text>
           </Card>
@@ -46,14 +46,14 @@ export default function ProfileScreen() {
             label="Upcoming"
             value="1"
             delta="Friday"
-            deltaTone="primary"
+            deltaColor="primary"
             description="Next booking"
           />
           <MetricCard
             label="Points"
             value="2,840"
             delta="+180"
-            deltaTone="success"
+            deltaColor="success"
             description="Loyalty balance"
           />
         </ScreenSection>

--- a/examples/food_drink/restaurant/app/(tabs)/reservations.tsx
+++ b/examples/food_drink/restaurant/app/(tabs)/reservations.tsx
@@ -38,12 +38,12 @@ export default function ReservationsScreen() {
           <Card
             title="Tonight"
             description="Tables available at 18:00, 19:30, and 21:00."
-            actions={<Badge tone="success">Open slots</Badge>}
+            actions={<Badge color="success">Open slots</Badge>}
           />
           <Notice
             title="Static reservation flow"
             description="Calendar availability, confirmation emails, and table management belong in a later backend example."
-            tone="primary"
+            color="primary"
           />
         </ScreenSection>
       </Screen>

--- a/examples/food_drink/restaurant/app/ExampleAppBar.tsx
+++ b/examples/food_drink/restaurant/app/ExampleAppBar.tsx
@@ -14,9 +14,9 @@ export function ExampleAppBar({ testID, title }: ExampleAppBarProps) {
         <IconButton
           icon={{ name: mode === 'dark' ? 'sunny-outline' : 'moon-outline' }}
           label={mode === 'dark' ? 'Use light mode' : 'Use dark mode'}
-          emphasis="ghost"
+          variant="ghost"
           size="m"
-          tone="neutral"
+          color="neutral"
           onPress={() => setMode(nextMode)}
         />
       }

--- a/examples/food_drink/restaurant/package.json
+++ b/examples/food_drink/restaurant/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ankhorage/zora": "^1.4.12",
+    "@ankhorage/zora": "^2.4.2",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-picker/picker": "2.11.1",
     "expo": "~54.0.34",

--- a/examples/shopping_commerce/marketplace/app/(tabs)/index.tsx
+++ b/examples/shopping_commerce/marketplace/app/(tabs)/index.tsx
@@ -35,7 +35,7 @@ export default function BrowseScreen() {
       <ExampleAppBar
         title="Browse"
         subtitle="Recommended marketplace listings from nearby sellers."
-        actions={<Badge tone="primary">Nearby</Badge>}
+        actions={<Badge color="primary">Nearby</Badge>}
       />
       <Screen>
         <ScreenSection
@@ -46,7 +46,7 @@ export default function BrowseScreen() {
             <MediaCard
               key={listing.title}
               {...listing}
-              badges={<Badge tone="success">Available</Badge>}
+              badges={<Badge color="success">Available</Badge>}
             />
           ))}
         </ScreenSection>
@@ -55,9 +55,9 @@ export default function BrowseScreen() {
           <Notice
             title="Needs commerce-specific cards"
             description="A real marketplace should have ProductCard/ProductGrid patterns for price, seller, distance, condition, and favorite state."
-            tone="warning"
+            color="warning"
           />
-          <Text tone="muted">
+          <Text emphasis="muted">
             This example records the product need without adding local card wrappers.
           </Text>
         </ScreenSection>

--- a/examples/shopping_commerce/marketplace/app/(tabs)/orders.tsx
+++ b/examples/shopping_commerce/marketplace/app/(tabs)/orders.tsx
@@ -28,13 +28,13 @@ export default function OrdersScreen() {
     <>
       <ExampleAppBar title="Orders" />
       <Screen>
-        <ScreenSection title="Summary" actions={<Badge tone="primary">3 active</Badge>}>
+        <ScreenSection title="Summary" actions={<Badge color="primary">3 active</Badge>}>
           <MetricCard label="Active orders" value="3" description="Purchases and offers" />
           <MetricCard
             label="Pending pickup"
             value="1"
             delta="Friday"
-            deltaTone="primary"
+            deltaColor="primary"
             description="Next appointment"
           />
           <MetricCard label="Open offers" value="2" description="Awaiting seller reply" />
@@ -50,7 +50,7 @@ export default function OrdersScreen() {
           <Notice
             title="Order lifecycle is static"
             description="Checkout, payment state, shipping, and dispute flows belong in later app/backend examples."
-            tone="primary"
+            color="primary"
           />
         </ScreenSection>
       </Screen>

--- a/examples/shopping_commerce/marketplace/app/(tabs)/profile.tsx
+++ b/examples/shopping_commerce/marketplace/app/(tabs)/profile.tsx
@@ -40,14 +40,14 @@ export default function ProfileScreen() {
         <ScreenSection
           title="Seller card"
           description="A commerce profile composed from existing ZORA cards."
-          actions={<Avatar name="Nora Frei" tone="primary" />}
+          actions={<Avatar name="Nora Frei" color="primary" />}
         >
           <Card
             title="Nora Frei"
             description="Zürich · 4.9 seller rating · replies within one hour"
-            actions={<Badge tone="success">Verified</Badge>}
+            actions={<Badge color="success">Verified</Badge>}
           >
-            <Text tone="muted">
+            <Text emphasis="muted">
               Local pickup preferred. Furniture, ceramics, and camera equipment.
             </Text>
           </Card>
@@ -59,7 +59,7 @@ export default function ProfileScreen() {
             label="Sold"
             value="128"
             delta="+12"
-            deltaTone="success"
+            deltaColor="success"
             description="Last 90 days"
           />
           <MetricCard label="Saved" value="36" description="Products and searches" />

--- a/examples/shopping_commerce/marketplace/app/(tabs)/sell.tsx
+++ b/examples/shopping_commerce/marketplace/app/(tabs)/sell.tsx
@@ -42,13 +42,13 @@ export default function SellScreen() {
           <Card
             title="Draft listing"
             description="Add photos, price, and pickup location before publishing."
-            actions={<Badge tone="warning">Draft</Badge>}
+            actions={<Badge color="warning">Draft</Badge>}
             tone="subtle"
           />
           <Notice
             title="Static commerce example"
             description="Payments, checkout, and seller verification belong outside this ZORA UI example."
-            tone="primary"
+            color="primary"
           />
         </ScreenSection>
       </Screen>

--- a/examples/shopping_commerce/storefront/app/(tabs)/cart.tsx
+++ b/examples/shopping_commerce/storefront/app/(tabs)/cart.tsx
@@ -38,12 +38,12 @@ export default function CartScreen() {
           <Card
             title="Order total"
             description="CHF 201 · shipping calculated later"
-            actions={<Badge tone="primary">3 items</Badge>}
+            actions={<Badge color="primary">3 items</Badge>}
           />
           <Notice
             title="Checkout is out of scope"
             description="The UI is static. Payments, taxes, shipping, and inventory reservation belong in app/backend examples later."
-            tone="primary"
+            color="primary"
           />
         </ScreenSection>
       </Screen>

--- a/examples/shopping_commerce/storefront/app/(tabs)/index.tsx
+++ b/examples/shopping_commerce/storefront/app/(tabs)/index.tsx
@@ -44,25 +44,25 @@ export default function HomeScreen() {
             <MediaCard
               key={product.title}
               {...product}
-              badges={<Badge tone="success">In stock</Badge>}
+              badges={<Badge color="success">In stock</Badge>}
             />
           ))}
         </ScreenSection>
 
-        <ScreenSection title="Social proof" actions={<Badge tone="primary">Spring edit</Badge>}>
+        <ScreenSection title="Social proof" actions={<Badge color="primary">Spring edit</Badge>}>
           <Notice
             title="1,248 happy customers"
             description="Static trust messaging for the example. Reviews and payments belong in app/backend layers later."
-            tone="success"
+            color="success"
           />
           <AvatarGroup
             items={[
-              { id: 'nora', name: 'Nora Frei', tone: 'primary' },
-              { id: 'mia', name: 'Mia Chen', tone: 'success' },
-              { id: 'lea', name: 'Lea Meyer', tone: 'warning' },
+              { id: 'nora', name: 'Nora Frei', color: 'primary' },
+              { id: 'mia', name: 'Mia Chen', color: 'success' },
+              { id: 'lea', name: 'Lea Meyer', color: 'warning' },
             ]}
           />
-          <Text tone="muted">
+          <Text emphasis="muted">
             A future StorefrontHero or ProductFeature pattern would make this screen stronger.
           </Text>
         </ScreenSection>

--- a/examples/shopping_commerce/storefront/app/(tabs)/orders.tsx
+++ b/examples/shopping_commerce/storefront/app/(tabs)/orders.tsx
@@ -28,13 +28,13 @@ export default function OrdersScreen() {
     <>
       <ExampleAppBar title="Orders" />
       <Screen>
-        <ScreenSection title="Order health" actions={<Badge tone="primary">1 active</Badge>}>
+        <ScreenSection title="Order health" actions={<Badge color="primary">1 active</Badge>}>
           <MetricCard label="Open orders" value="1" description="Preparing shipment" />
           <MetricCard
             label="Delivered"
             value="12"
             delta="+3"
-            deltaTone="success"
+            deltaColor="success"
             description="Last 90 days"
           />
           <MetricCard label="Returns" value="0" description="No active return requests" />
@@ -50,7 +50,7 @@ export default function OrdersScreen() {
           <Notice
             title="Fulfillment is static"
             description="Tracking, refunds, returns, and notifications belong in later app/backend examples."
-            tone="primary"
+            color="primary"
           />
         </ScreenSection>
       </Screen>

--- a/examples/shopping_commerce/storefront/app/(tabs)/products.tsx
+++ b/examples/shopping_commerce/storefront/app/(tabs)/products.tsx
@@ -37,9 +37,15 @@ export default function ProductsScreen() {
         <ScreenSection
           title="Search"
           description="Filtering is static for now, but the UI surface is real."
-          actions={<Badge tone="primary">42 items</Badge>}
+          actions={<Badge color="primary">42 items</Badge>}
         >
-          <SearchBar value="" placeholder="Search products" />
+          <SearchBar
+            onValueChange={() => {
+              /* no-op */
+            }}
+            value=""
+            placeholder="Search products"
+          />
         </ScreenSection>
 
         <ScreenSection
@@ -50,10 +56,10 @@ export default function ProductsScreen() {
             <MediaCard
               key={product.title}
               {...product}
-              badges={<Badge tone="success">Available</Badge>}
+              badges={<Badge color="success">Available</Badge>}
             />
           ))}
-          <Text tone="muted">
+          <Text emphasis="muted">
             Storefront needs ProductCard, ProductGrid, price, sale, and inventory-aware patterns
             later.
           </Text>

--- a/examples/shopping_commerce/storefront/app/(tabs)/profile.tsx
+++ b/examples/shopping_commerce/storefront/app/(tabs)/profile.tsx
@@ -37,13 +37,13 @@ export default function ProfileScreen() {
     <>
       <ExampleAppBar title="Customer profile" />
       <Screen>
-        <ScreenSection title="Customer card" actions={<Avatar name="Nora Frei" tone="primary" />}>
+        <ScreenSection title="Customer card" actions={<Avatar name="Nora Frei" color="primary" />}>
           <Card
             title="Nora Frei"
             description="Studio customer · Zürich · member since 2024"
-            actions={<Badge tone="success">Gold member</Badge>}
+            actions={<Badge color="success">Gold member</Badge>}
           >
-            <Text tone="muted">
+            <Text emphasis="muted">
               Prefers natural materials, ceramic sets, and quiet tableware collections.
             </Text>
           </Card>
@@ -54,7 +54,7 @@ export default function ProfileScreen() {
             label="Points"
             value="4,280"
             delta="+320"
-            deltaTone="success"
+            deltaColor="success"
             description="This month"
           />
           <MetricCard label="Orders" value="13" description="Lifetime purchases" />

--- a/examples/shopping_commerce/storefront/package.json
+++ b/examples/shopping_commerce/storefront/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ankhorage/zora": "^1.4.12",
+    "@ankhorage/zora": "latest",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-picker/picker": "2.11.1",
     "expo": "~54.0.34",

--- a/examples/social_community/community-feed/app/(tabs)/groups.tsx
+++ b/examples/social_community/community-feed/app/(tabs)/groups.tsx
@@ -39,7 +39,7 @@ export default function GroupsScreen() {
         <ScreenSection
           title="Featured room"
           description="A composed ZORA card for the most active group."
-          actions={<Badge tone="primary">3 active</Badge>}
+          actions={<Badge color="primary">3 active</Badge>}
         >
           <Card
             title="Design systems circle"
@@ -48,13 +48,13 @@ export default function GroupsScreen() {
               <AvatarGroup
                 items={[
                   { id: 'mia', name: 'Mia Chen' },
-                  { id: 'noah', name: 'Noah Keller', tone: 'success' },
-                  { id: 'lea', name: 'Lea Meyer', tone: 'warning' },
+                  { id: 'noah', name: 'Noah Keller', color: 'success' },
+                  { id: 'lea', name: 'Lea Meyer', color: 'warning' },
                 ]}
               />
             }
           >
-            <Text tone="muted">The screen stays realistic without local layout wrappers.</Text>
+            <Text emphasis="muted">The screen stays realistic without local layout wrappers.</Text>
           </Card>
         </ScreenSection>
 

--- a/examples/social_community/community-feed/app/(tabs)/messages.tsx
+++ b/examples/social_community/community-feed/app/(tabs)/messages.tsx
@@ -7,21 +7,21 @@ const conversations = [
     title: 'Mia Chen',
     description: 'Sent feedback on the onboarding flow two minutes ago.',
     meta: 'Now',
-    leading: <Avatar name="Mia Chen" tone="primary" />,
+    leading: <Avatar name="Mia Chen" color="primary" />,
     variant: 'card' as const,
   },
   {
     title: 'Noah Keller',
     description: 'Shared the event checklist for Friday.',
     meta: '18m',
-    leading: <Avatar name="Noah Keller" tone="success" />,
+    leading: <Avatar name="Noah Keller" color="success" />,
     variant: 'card' as const,
   },
   {
     title: 'Lea Meyer',
     description: 'Asked for a second review on the profile card.',
     meta: '1h',
-    leading: <Avatar name="Lea Meyer" tone="warning" />,
+    leading: <Avatar name="Lea Meyer" color="warning" />,
     variant: 'card' as const,
   },
 ] as const;
@@ -34,13 +34,13 @@ export default function MessagesScreen() {
         <ScreenSection
           title="Pinned"
           description="The first message preview uses a reusable ZORA panel."
-          actions={<Badge tone="primary">3 unread</Badge>}
+          actions={<Badge color="primary">3 unread</Badge>}
         >
           <Panel
             title="Mia Chen"
             description="Sent feedback on the onboarding flow two minutes ago."
           >
-            <Text tone="muted">
+            <Text emphasis="muted">
               The next iteration can replace this with a dedicated ChatList pattern when the app
               needs richer message states.
             </Text>

--- a/examples/social_community/community-feed/app/(tabs)/profile.tsx
+++ b/examples/social_community/community-feed/app/(tabs)/profile.tsx
@@ -17,7 +17,9 @@ export default function ProfileScreen() {
             description="Community host · Product design · Mobile UX"
             actions={<Badge color="success">Active</Badge>}
           >
-            <Text emphasis="muted">1.8k followers · 243 saved posts · 32 active conversations.</Text>
+            <Text emphasis="muted">
+              1.8k followers · 243 saved posts · 32 active conversations.
+            </Text>
           </Card>
         </ScreenSection>
 

--- a/examples/social_community/community-feed/app/(tabs)/profile.tsx
+++ b/examples/social_community/community-feed/app/(tabs)/profile.tsx
@@ -10,14 +10,14 @@ export default function ProfileScreen() {
         <ScreenSection
           title="Creator profile"
           description="A profile route composed from public ZORA exports."
-          actions={<Avatar name="Ava Studio" tone="primary" />}
+          actions={<Avatar name="Ava Studio" color="primary" />}
         >
           <Card
             title="Ava Studio"
             description="Community host · Product design · Mobile UX"
-            actions={<Badge tone="success">Active</Badge>}
+            actions={<Badge color="success">Active</Badge>}
           >
-            <Text tone="muted">1.8k followers · 243 saved posts · 32 active conversations.</Text>
+            <Text emphasis="muted">1.8k followers · 243 saved posts · 32 active conversations.</Text>
           </Card>
         </ScreenSection>
 
@@ -26,7 +26,7 @@ export default function ProfileScreen() {
             label="Followers"
             value="1.8k"
             delta="+8%"
-            deltaTone="success"
+            deltaColor="success"
             description="Last 30 days"
           />
           <MetricCard label="Saved posts" value="243" description="Across public groups" />
@@ -34,7 +34,7 @@ export default function ProfileScreen() {
             label="Replies"
             value="612"
             delta="+14"
-            deltaTone="primary"
+            deltaColor="primary"
             description="This month"
           />
         </ScreenSection>

--- a/examples/social_community/community-feed/app/(tabs)/settings.tsx
+++ b/examples/social_community/community-feed/app/(tabs)/settings.tsx
@@ -32,7 +32,7 @@ export default function SettingsScreen() {
           <Notice
             title="Template-ready settings"
             description="This route is intentionally static. Data binding belongs in a later template/runtime step."
-            tone="primary"
+            color="primary"
           />
         </ScreenSection>
 
@@ -42,11 +42,11 @@ export default function SettingsScreen() {
           items={settingsRows}
         />
 
-        <ScreenSection title="Account" actions={<Badge tone="neutral">Starter</Badge>}>
+        <ScreenSection title="Account" actions={<Badge color="neutral">Starter</Badge>}>
           <Card
             title="Community Feed example"
             description="Real Expo Router app, ZORA-only UI, category-based location."
-            actions={<Badge tone="success">Verified shape</Badge>}
+            actions={<Badge color="success">Verified shape</Badge>}
             tone="subtle"
           />
         </ScreenSection>

--- a/examples/social_community/community-feed/package.json
+++ b/examples/social_community/community-feed/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ankhorage/zora": "^1.4.12",
+    "@ankhorage/zora": "latest",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-picker/picker": "2.11.1",
     "expo": "~54.0.34",

--- a/examples/social_community/photo-social/app/(tabs)/activity.tsx
+++ b/examples/social_community/photo-social/app/(tabs)/activity.tsx
@@ -7,21 +7,21 @@ const activityRows = [
     title: 'Mia liked your carousel',
     description: 'Golden hour terrace received a new reaction.',
     meta: '2m',
-    leading: <Avatar name="Mia Chen" tone="primary" />,
+    leading: <Avatar name="Mia Chen" color="primary" />,
     variant: 'card' as const,
   },
   {
     title: 'Marco saved your post',
     description: 'City textures was added to his inspiration board.',
     meta: '18m',
-    leading: <Avatar name="Marco Silva" tone="success" />,
+    leading: <Avatar name="Marco Silva" color="success" />,
     variant: 'card' as const,
   },
   {
     title: 'Aya commented',
     description: 'Asked which lens you used for the night market photo.',
     meta: '1h',
-    leading: <Avatar name="Aya Novak" tone="warning" />,
+    leading: <Avatar name="Aya Novak" color="warning" />,
     variant: 'card' as const,
   },
 ] as const;
@@ -32,14 +32,14 @@ export default function ActivityScreen() {
       <ExampleAppBar
         title="Activity"
         subtitle="Likes, saves, comments, follows, and creator updates."
-        actions={<Badge tone="primary">3 new</Badge>}
+        actions={<Badge color="primary">3 new</Badge>}
       />
       <Screen>
         <ScreenSection title="Highlights">
           <Notice
             title="Audience is active"
             description="Your last photo story is driving more saves than comments today."
-            tone="success"
+            color="success"
           />
         </ScreenSection>
 

--- a/examples/social_community/photo-social/app/(tabs)/create.tsx
+++ b/examples/social_community/photo-social/app/(tabs)/create.tsx
@@ -36,7 +36,7 @@ export default function CreateScreen() {
           <Card
             title="Draft quality"
             description="Add a location, topic, and short caption before publishing."
-            actions={<Badge tone="warning">Draft</Badge>}
+            actions={<Badge color="warning">Draft</Badge>}
             tone="subtle"
           />
         </ScreenSection>
@@ -45,7 +45,7 @@ export default function CreateScreen() {
           <Notice
             title="Static example only"
             description="This route demonstrates the composition surface. Upload persistence belongs in app/backend examples later."
-            tone="primary"
+            color="primary"
           />
         </ScreenSection>
       </Screen>

--- a/examples/social_community/photo-social/app/(tabs)/explore.tsx
+++ b/examples/social_community/photo-social/app/(tabs)/explore.tsx
@@ -35,14 +35,20 @@ export default function ExploreScreen() {
       <ExampleAppBar
         title="Explore"
         subtitle="Discover visual collections and creator-led image themes."
-        actions={<Badge tone="primary">Trending</Badge>}
+        actions={<Badge color="primary">Trending</Badge>}
       />
       <Screen>
         <ScreenSection
           title="Search"
           description="The search control is part of the ZORA component surface."
         >
-          <SearchBar value="" placeholder="Search creators, places, styles" />
+          <SearchBar
+            onValueChange={() => {
+              /* no-op */
+            }}
+            value=""
+            placeholder="Search creators, places, styles"
+          />
         </ScreenSection>
 
         <ScreenSection
@@ -53,10 +59,10 @@ export default function ExploreScreen() {
             <MediaCard
               key={collection.title}
               {...collection}
-              badges={<Badge tone="neutral">Featured</Badge>}
+              badges={<Badge color="neutral">Featured</Badge>}
             />
           ))}
-          <Text tone="muted">
+          <Text emphasis="muted">
             A richer visual discovery template should probably introduce a dedicated Wall/Grid
             pattern later.
           </Text>

--- a/examples/social_community/photo-social/app/(tabs)/index.tsx
+++ b/examples/social_community/photo-social/app/(tabs)/index.tsx
@@ -44,7 +44,7 @@ export default function HomeScreen() {
         <ScreenSection
           title="Stories"
           description="Avatar groups and badges give the feed a social rhythm without custom styles."
-          actions={<Badge tone="success">Live feed</Badge>}
+          actions={<Badge color="success">Live feed</Badge>}
         >
           <MediaCard
             title="Weekend makers"
@@ -53,13 +53,13 @@ export default function HomeScreen() {
               uri: 'https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=1200&q=80',
             }}
             imageLabel="People at a creative event"
-            badges={<Badge tone="primary">12 updates</Badge>}
+            badges={<Badge color="primary">12 updates</Badge>}
             footer={
               <AvatarGroup
                 items={[
                   { id: 'lina', name: 'Lina Brooks' },
-                  { id: 'marco', name: 'Marco Silva', tone: 'success' },
-                  { id: 'aya', name: 'Aya Novak', tone: 'warning' },
+                  { id: 'marco', name: 'Marco Silva', color: 'success' },
+                  { id: 'aya', name: 'Aya Novak', color: 'warning' },
                 ]}
               />
             }
@@ -71,7 +71,7 @@ export default function HomeScreen() {
           description="A realistic image-first feed using the ZORA PostCard pattern."
         >
           <PostCard {...featuredPost} />
-          <Text tone="muted">
+          <Text emphasis="muted">
             The first missing ZORA gap will probably be a dedicated visual grid/masonry pattern.
           </Text>
         </ScreenSection>

--- a/examples/social_community/photo-social/app/(tabs)/profile.tsx
+++ b/examples/social_community/photo-social/app/(tabs)/profile.tsx
@@ -17,7 +17,7 @@ export default function ProfileScreen() {
       <ExampleAppBar
         title="Lina Brooks"
         subtitle="Street color studies, interiors, and quiet city frames."
-        actions={<Avatar name="Lina Brooks" tone="primary" />}
+        actions={<Avatar name="Lina Brooks" color="primary" />}
       />
       <Screen>
         <ScreenSection
@@ -27,9 +27,9 @@ export default function ProfileScreen() {
           <Card
             title="@linabrooks"
             description="Photographer · Zürich · 128 posts"
-            actions={<Badge tone="success">Following</Badge>}
+            actions={<Badge color="success">Following</Badge>}
           >
-            <Text tone="muted">Golden hour, street signs, and calm interior details.</Text>
+            <Text emphasis="muted">Golden hour, street signs, and calm interior details.</Text>
           </Card>
         </ScreenSection>
 
@@ -38,7 +38,7 @@ export default function ProfileScreen() {
             label="Followers"
             value="24.8k"
             delta="+3.2%"
-            deltaTone="success"
+            deltaColor="success"
             description="Last 30 days"
           />
           <MetricCard label="Saves" value="8.4k" description="Across all posts" />
@@ -53,7 +53,7 @@ export default function ProfileScreen() {
               uri: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80',
             }}
             imageLabel="Warm city terrace at golden hour"
-            badges={<Badge tone="primary">Featured</Badge>}
+            badges={<Badge color="primary">Featured</Badge>}
           />
         </ScreenSection>
       </Screen>

--- a/examples/social_community/photo-social/package.json
+++ b/examples/social_community/photo-social/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ankhorage/zora": "^1.4.12",
+    "@ankhorage/zora": "latest",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-picker/picker": "2.11.1",
     "expo": "~54.0.34",

--- a/examples/social_community/private-messaging/app/(tabs)/calls.tsx
+++ b/examples/social_community/private-messaging/app/(tabs)/calls.tsx
@@ -7,9 +7,9 @@ const callRows = [
     title: 'Mia Chen',
     description: 'Missed voice call',
     meta: 'Today · 09:12',
-    leading: <Avatar name="Mia Chen" tone="primary" />,
+    leading: <Avatar name="Mia Chen" color="primary" />,
     action: (
-      <Button emphasis="ghost" leadingIcon={{ name: 'call-outline' }}>
+      <Button variant="ghost" leadingIcon={{ name: 'call-outline' }}>
         Call
       </Button>
     ),
@@ -19,9 +19,9 @@ const callRows = [
     title: 'Noah Keller',
     description: 'Outgoing video call',
     meta: 'Yesterday · 18:44',
-    leading: <Avatar name="Noah Keller" tone="success" />,
+    leading: <Avatar name="Noah Keller" color="success" />,
     action: (
-      <Button emphasis="ghost" leadingIcon={{ name: 'videocam-outline' }}>
+      <Button variant="ghost" leadingIcon={{ name: 'videocam-outline' }}>
         Video
       </Button>
     ),
@@ -31,9 +31,9 @@ const callRows = [
     title: 'Lea Meyer',
     description: 'Incoming voice call',
     meta: 'Monday · 14:05',
-    leading: <Avatar name="Lea Meyer" tone="warning" />,
+    leading: <Avatar name="Lea Meyer" color="warning" />,
     action: (
-      <Button emphasis="ghost" leadingIcon={{ name: 'call-outline' }}>
+      <Button variant="ghost" leadingIcon={{ name: 'call-outline' }}>
         Call
       </Button>
     ),
@@ -47,14 +47,14 @@ export default function CallsScreen() {
       <ExampleAppBar
         title="Calls"
         subtitle="Recent voice and video interactions for a private messaging app."
-        actions={<Badge tone="neutral">Static</Badge>}
+        actions={<Badge color="neutral">Static</Badge>}
       />
       <Screen>
         <ScreenSection title="Availability">
           <Notice
             title="Call history only"
             description="The example models the UI surface. Real voice/video infrastructure belongs outside ZORA."
-            tone="primary"
+            color="primary"
           />
         </ScreenSection>
 

--- a/examples/social_community/private-messaging/app/(tabs)/contacts.tsx
+++ b/examples/social_community/private-messaging/app/(tabs)/contacts.tsx
@@ -15,9 +15,9 @@ const contactRows = [
     title: 'Mia Chen',
     description: 'Product designer · Available',
     meta: 'Online',
-    leading: <Avatar name="Mia Chen" tone="primary" />,
+    leading: <Avatar name="Mia Chen" color="primary" />,
     action: (
-      <Button emphasis="ghost" leadingIcon={{ name: 'chatbubble-outline' }}>
+      <Button variant="ghost" leadingIcon={{ name: 'chatbubble-outline' }}>
         Message
       </Button>
     ),
@@ -27,9 +27,9 @@ const contactRows = [
     title: 'Noah Keller',
     description: 'Community operations · Busy until 14:00',
     meta: 'Busy',
-    leading: <Avatar name="Noah Keller" tone="success" />,
+    leading: <Avatar name="Noah Keller" color="success" />,
     action: (
-      <Button emphasis="ghost" leadingIcon={{ name: 'chatbubble-outline' }}>
+      <Button variant="ghost" leadingIcon={{ name: 'chatbubble-outline' }}>
         Message
       </Button>
     ),
@@ -39,9 +39,9 @@ const contactRows = [
     title: 'Lea Meyer',
     description: 'Frontend engineer · Usually replies in an hour',
     meta: 'Away',
-    leading: <Avatar name="Lea Meyer" tone="warning" />,
+    leading: <Avatar name="Lea Meyer" color="warning" />,
     action: (
-      <Button emphasis="ghost" leadingIcon={{ name: 'chatbubble-outline' }}>
+      <Button variant="ghost" leadingIcon={{ name: 'chatbubble-outline' }}>
         Message
       </Button>
     ),
@@ -55,14 +55,20 @@ export default function ContactsScreen() {
       <ExampleAppBar
         title="Contacts"
         subtitle="People and groups available for direct messages."
-        actions={<Badge tone="primary">128 contacts</Badge>}
+        actions={<Badge color="primary">128 contacts</Badge>}
       />
       <Screen>
         <ScreenSection
           title="Find people"
           description="A searchable contact directory without local input styling."
         >
-          <SearchBar value="" placeholder="Search contacts" />
+          <SearchBar
+            onValueChange={() => {
+              /* no-op */
+            }}
+            value=""
+            placeholder="Search contacts"
+          />
         </ScreenSection>
 
         <ListSection

--- a/examples/social_community/private-messaging/app/(tabs)/index.tsx
+++ b/examples/social_community/private-messaging/app/(tabs)/index.tsx
@@ -48,13 +48,19 @@ export default function ChatsScreen() {
           title="Search"
           description="Search is a first-class ZORA component, not local input glue."
         >
-          <SearchBar value="" placeholder="Search chats" />
+          <SearchBar
+            onValueChange={() => {
+              /* no-op */
+            }}
+            value=""
+            placeholder="Search chats"
+          />
         </ScreenSection>
 
         <ScreenSection
           title="Pinned"
           description="ChatListItem carries the main inbox interaction shape."
-          actions={<Badge tone="primary">3 chats</Badge>}
+          actions={<Badge color="primary">3 chats</Badge>}
         >
           {chats.map((chat) => (
             <ChatListItem key={chat.title} {...chat} />
@@ -65,10 +71,10 @@ export default function ChatsScreen() {
           <Card
             title="Next ZORA pressure point"
             description="A full ChatScreen pattern should handle message bubbles, composer, date separators, and attachments."
-            actions={<Badge tone="warning">Follow-up</Badge>}
+            actions={<Badge color="warning">Follow-up</Badge>}
             tone="subtle"
           >
-            <Text tone="muted">
+            <Text emphasis="muted">
               This example intentionally stays static until ZORA owns the missing chat primitives.
             </Text>
           </Card>

--- a/examples/social_community/private-messaging/app/(tabs)/status.tsx
+++ b/examples/social_community/private-messaging/app/(tabs)/status.tsx
@@ -8,7 +8,7 @@ export default function StatusScreen() {
       <ExampleAppBar
         title="Status"
         subtitle="Short-lived updates from contacts and groups."
-        actions={<Badge tone="primary">4 updates</Badge>}
+        actions={<Badge color="primary">4 updates</Badge>}
       />
       <Screen>
         <ScreenSection
@@ -22,7 +22,7 @@ export default function StatusScreen() {
               uri: 'https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=1200&q=80',
             }}
             imageLabel="People at a small gathering"
-            badges={<Badge tone="success">Ready</Badge>}
+            badges={<Badge color="success">Ready</Badge>}
           />
         </ScreenSection>
 
@@ -36,14 +36,14 @@ export default function StatusScreen() {
             actions={
               <AvatarGroup
                 items={[
-                  { id: 'noah', name: 'Noah Keller', tone: 'success' },
-                  { id: 'mia', name: 'Mia Chen', tone: 'primary' },
-                  { id: 'lea', name: 'Lea Meyer', tone: 'warning' },
+                  { id: 'noah', name: 'Noah Keller', color: 'success' },
+                  { id: 'mia', name: 'Mia Chen', color: 'primary' },
+                  { id: 'lea', name: 'Lea Meyer', color: 'warning' },
                 ]}
               />
             }
           >
-            <Text tone="muted">
+            <Text emphasis="muted">
               A future Status pattern could model rings, expiry, and grouped story states.
             </Text>
           </Card>

--- a/examples/social_community/private-messaging/package.json
+++ b/examples/social_community/private-messaging/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ankhorage/zora": "^1.4.12",
+    "@ankhorage/zora": "latest",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-picker/picker": "2.11.1",
     "expo": "~54.0.34",

--- a/examples/social_community/visual-discovery/app/(tabs)/boards.tsx
+++ b/examples/social_community/visual-discovery/app/(tabs)/boards.tsx
@@ -37,7 +37,7 @@ export default function BoardsScreen() {
       <ExampleAppBar
         title="Boards"
         subtitle="Organize saved ideas into reusable visual collections."
-        actions={<Badge tone="primary">12 boards</Badge>}
+        actions={<Badge color="primary">12 boards</Badge>}
       />
       <Screen>
         <ScreenSection
@@ -50,14 +50,14 @@ export default function BoardsScreen() {
             actions={
               <AvatarGroup
                 items={[
-                  { id: 'mia', name: 'Mia Chen', tone: 'primary' },
-                  { id: 'noah', name: 'Noah Keller', tone: 'success' },
-                  { id: 'lea', name: 'Lea Meyer', tone: 'warning' },
+                  { id: 'mia', name: 'Mia Chen', color: 'primary' },
+                  { id: 'noah', name: 'Noah Keller', color: 'success' },
+                  { id: 'lea', name: 'Lea Meyer', color: 'warning' },
                 ]}
               />
             }
           >
-            <Text tone="muted">
+            <Text emphasis="muted">
               Shared boards are static here; collaboration features belong later.
             </Text>
           </Card>

--- a/examples/social_community/visual-discovery/app/(tabs)/index.tsx
+++ b/examples/social_community/visual-discovery/app/(tabs)/index.tsx
@@ -51,16 +51,22 @@ export default function DiscoverScreen() {
           title="Search"
           description="Visual discovery starts with a broad idea or mood."
         >
-          <SearchBar value="" placeholder="Search ideas, boards, products, places" />
+          <SearchBar
+            value=""
+            onValueChange={() => {
+              /* no-op */
+            }}
+            placeholder="Search ideas, boards, products, places"
+          />
         </ScreenSection>
 
         <ScreenSection
           title="For you"
           description="Existing ZORA media cards stand in for a future Wall/Grid pattern."
-          actions={<Badge tone="primary">Personalized</Badge>}
+          actions={<Badge color="primary">Personalized</Badge>}
         >
           {pins.map((pin) => (
-            <MediaCard key={pin.title} {...pin} badges={<Badge tone="neutral">Pin</Badge>} />
+            <MediaCard key={pin.title} {...pin} badges={<Badge color="neutral">Pin</Badge>} />
           ))}
         </ScreenSection>
 
@@ -68,9 +74,9 @@ export default function DiscoverScreen() {
           <Notice
             title="Needs a visual wall pattern"
             description="The app works, but a Pinterest-style template should eventually use a dedicated Wall/Grid or Masonry pattern instead of a simple card flow."
-            tone="warning"
+            color="warning"
           />
-          <Text tone="muted">
+          <Text emphasis="muted">
             This example captures the product need without adding local layout tricks.
           </Text>
         </ScreenSection>

--- a/examples/social_community/visual-discovery/app/(tabs)/profile.tsx
+++ b/examples/social_community/visual-discovery/app/(tabs)/profile.tsx
@@ -17,7 +17,7 @@ export default function ProfileScreen() {
       <ExampleAppBar
         title="Mira Stone"
         subtitle="Curator of interiors, market colors, and compact travel boards."
-        actions={<Avatar name="Mira Stone" tone="primary" />}
+        actions={<Avatar name="Mira Stone" color="primary" />}
       />
       <Screen>
         <ScreenSection
@@ -27,9 +27,9 @@ export default function ProfileScreen() {
           <Card
             title="@mirastone"
             description="18 public boards · 2.4k followers · weekly visual notes"
-            actions={<Badge tone="success">Curator</Badge>}
+            actions={<Badge color="success">Curator</Badge>}
           >
-            <Text tone="muted">
+            <Text emphasis="muted">
               Collecting calm spaces, food stories, and practical inspiration boards.
             </Text>
           </Card>
@@ -40,7 +40,7 @@ export default function ProfileScreen() {
             label="Followers"
             value="2.4k"
             delta="+11%"
-            deltaTone="success"
+            deltaColor="success"
             description="Last 30 days"
           />
           <MetricCard label="Pins" value="684" description="Across public boards" />
@@ -55,7 +55,7 @@ export default function ProfileScreen() {
               uri: 'https://images.unsplash.com/photo-1518005020951-eccb494ad742?auto=format&fit=crop&w=1200&q=80',
             }}
             imageLabel="Warm studio workspace with design objects"
-            badges={<Badge tone="primary">Featured board</Badge>}
+            badges={<Badge color="primary">Featured board</Badge>}
           />
         </ScreenSection>
       </Screen>

--- a/examples/social_community/visual-discovery/app/(tabs)/saved.tsx
+++ b/examples/social_community/visual-discovery/app/(tabs)/saved.tsx
@@ -27,7 +27,7 @@ export default function SavedScreen() {
       <ExampleAppBar
         title="Saved"
         subtitle="Recently saved pins, boards, and visual references."
-        actions={<Badge tone="success">230 saved</Badge>}
+        actions={<Badge color="success">230 saved</Badge>}
       />
       <Screen>
         <ScreenSection
@@ -35,9 +35,9 @@ export default function SavedScreen() {
           description="A simple saved-items flow using existing media cards."
         >
           {savedItems.map((item) => (
-            <MediaCard key={item.title} {...item} badges={<Badge tone="primary">Saved</Badge>} />
+            <MediaCard key={item.title} {...item} badges={<Badge color="primary">Saved</Badge>} />
           ))}
-          <Text tone="muted">
+          <Text emphasis="muted">
             Saved collections will become stronger once ZORA has a dedicated visual grid pattern.
           </Text>
         </ScreenSection>

--- a/examples/social_community/visual-discovery/app/(tabs)/trends.tsx
+++ b/examples/social_community/visual-discovery/app/(tabs)/trends.tsx
@@ -29,7 +29,7 @@ export default function TrendsScreen() {
       <ExampleAppBar
         title="Trends"
         subtitle="Signals that help creators decide what to save, organize, and publish next."
-        actions={<Badge tone="primary">Weekly</Badge>}
+        actions={<Badge color="primary">Weekly</Badge>}
       />
       <Screen>
         <ScreenSection title="Signals">
@@ -37,14 +37,14 @@ export default function TrendsScreen() {
             label="Pins saved"
             value="42k"
             delta="+18%"
-            deltaTone="success"
+            deltaColor="success"
             description="This week"
           />
           <MetricCard
             label="Boards created"
             value="8.7k"
             delta="+6%"
-            deltaTone="primary"
+            deltaColor="primary"
             description="Across visual topics"
           />
           <MetricCard
@@ -64,7 +64,7 @@ export default function TrendsScreen() {
           <Notice
             title="Trend cards are a future pattern"
             description="A real visual discovery product likely needs richer trend cards with thumbnails, stats, and related boards."
-            tone="warning"
+            color="warning"
           />
         </ScreenSection>
       </Screen>

--- a/examples/social_community/visual-discovery/package.json
+++ b/examples/social_community/visual-discovery/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ankhorage/zora": "^1.4.12",
+    "@ankhorage/zora": "latest",
     "@expo/vector-icons": "^15.1.1",
     "@react-native-picker/picker": "2.11.1",
     "expo": "~54.0.34",

--- a/src/patterns/notice/meta.ts
+++ b/src/patterns/notice/meta.ts
@@ -10,7 +10,7 @@ export const noticeMeta = {
     label: 'Notice',
     defaultProps: {
       title: 'Notice',
-      tone: 'primary',
+      color: 'primary',
     },
   },
   props: {
@@ -25,10 +25,10 @@ export const noticeMeta = {
       category: 'Content',
       label: 'Description',
     },
-    tone: {
+    color: {
       type: 'enum',
       category: 'Style',
-      label: 'Tone',
+      label: 'Color',
       enum: ['primary', 'neutral', 'danger', 'success', 'warning'],
       default: 'primary',
     },


### PR DESCRIPTION
## Summary

- update `Notice` component metadata from `tone` to `color`
- update the `Notice` insertion blueprint default props to use `color: 'primary'`
- update realistic example apps from stale semantic color prop names to current public APIs:
  - `Badge tone` -> `Badge color`
  - `Avatar tone` -> `Avatar color`
  - `Text tone="muted"` -> `Text emphasis="muted"`
  - `Notice tone` -> `Notice color`
  - `MetricCard deltaTone` -> `MetricCard deltaColor`
- keep valid card surface `tone` props unchanged on `Card`, `MediaCard`, and `MetricCard`
- add a patch changeset

## Notes

Runtime/types for the affected components already use the current names. The stale usage was in component metadata and realistic examples.

Audit result:

- `Badge` public API uses `color`
- `IconButton` public API uses `color`
- `Avatar` public API uses `color`
- `Notice` public API uses `color`
- `MetricCard` public API uses `deltaColor`
- `MetricCard.tone` remains valid because it is `ZoraCardTone` and is passed to `Card`
- `MediaCard.tone` remains valid because it is `ZoraCardTone` and is passed to `Card`

## Verification

Not run locally in this environment because the connected GitHub API path cannot execute repo commands. Please run before merge:

```bash
bun run build
bun run lint:fix
bun run test
```