### PR TITLE
feat: add action surface wrappers

### DIFF
--- a/.changeset/action-surfaces.md
+++ b/.changeset/action-surfaces.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Expose Surface-backed Menu, DropdownMenu, ActionSheet, and ActionSheetItem components.

--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ Metadata model overview:
 <details>
 <summary>Components</summary>
 
+- `ActionSheet`
+- `ActionSheetItem`
 - `AppBar`
 - `Avatar`
 - `AvatarGroup`
@@ -299,6 +301,7 @@ Metadata model overview:
 - `CheckboxGroup`
 - `Chip`
 - `ChipGroup`
+- `DropdownMenu`
 - `Drawer`
 - `Form`
 - `FormActions`
@@ -1154,6 +1157,158 @@ Inherits all Surface `TextareaProps` except `leadingAccessory`, `size`, and
 except `multiline`, so React Native text input props are available through
 Surface with the same Surface exclusions and re-exposed values listed for
 `Input`.
+
+</details>
+
+### `Menu` / `DropdownMenu` / `ActionSheet`
+
+Action-surface components for overflow actions, row actions, card actions, toolbar
+menus, profile actions, destructive entry points, and mobile-friendly contextual
+action sheets.
+
+`Menu` and `DropdownMenu` expose app-facing action specs while delegating the
+low-level trigger, portal, focus, keyboard, and dismissal behavior to Surface.
+`ActionSheet` and `ActionSheetItem` expose a mobile-friendly contextual action
+surface backed by Surface.
+
+```tsx
+<Menu
+  trigger={<IconButton icon={{ name: 'ellipsis-horizontal' }} label="More actions" />}
+  actions={[
+    {
+      id: 'edit',
+      title: 'Edit',
+      icon: { name: 'create-outline' },
+      onPress: edit,
+    },
+    {
+      id: 'duplicate',
+      title: 'Duplicate',
+      icon: { name: 'copy-outline' },
+      onPress: duplicate,
+    },
+    {
+      id: 'delete',
+      title: 'Delete',
+      description: 'Remove this item permanently.',
+      icon: { name: 'trash-outline' },
+      intent: 'danger',
+      onPress: remove,
+    },
+  ]}
+/>
+```
+
+`DropdownMenu` is an app-facing alias for the same trigger/actions composition:
+
+```tsx
+<DropdownMenu
+  trigger={<Button variant="outline">Sort</Button>}
+  actions={[
+    { id: 'newest', title: 'Newest first', selected: true, onPress: sortNewest },
+    { id: 'oldest', title: 'Oldest first', onPress: sortOldest },
+  ]}
+/>
+```
+
+Use `ActionSheet` for a modal contextual action surface:
+
+```tsx
+<ActionSheet
+  visible={sheetVisible}
+  onDismiss={() => setSheetVisible(false)}
+  title="Project actions"
+  description="Choose what to do with this project."
+>
+  <ActionSheetItem label="Edit" icon={{ name: 'create-outline' }} onPress={edit} />
+  <ActionSheetItem label="Duplicate" icon={{ name: 'copy-outline' }} onPress={duplicate} />
+  <ActionSheetItem
+    color="danger"
+    label="Delete"
+    icon={{ name: 'trash-outline' }}
+    onPress={remove}
+  />
+</ActionSheet>
+```
+
+These components do not own command-palette behavior, nested menus, data-table
+row logic, or global shortcut handling.
+
+<details>
+<summary>Props</summary>
+
+`Menu` / `DropdownMenu` props:
+
+| Prop            | Type                    | Default | Notes                                      |
+| --------------- | ----------------------- | ------- | ------------------------------------------ |
+| `trigger`       | `React.ReactNode`       | -       | Element used to open/close the menu.       |
+| `actions`       | `readonly MenuAction[]` | -       | Structured action rows.                    |
+| `onDismiss`     | `() => void`            | -       | Called when the menu is dismissed.         |
+| `closeOnSelect` | `boolean`               | `true`  | Closes the menu after an action activates. |
+| `testID`        | `string`                | -       | Test id.                                   |
+| `mode`          | `ZoraThemeMode`         | -       | Optional scoped theme mode override.       |
+| `themeId`       | `ZoraThemeId`           | -       | Optional scoped theme id override.         |
+
+`MenuAction` fields:
+
+| Field         | Type               | Default | Notes                                        |
+| ------------- | ------------------ | ------- | -------------------------------------------- |
+| `id`          | `string`           | -       | Stable action id.                            |
+| `title`       | `React.ReactNode`  | -       | Main action label.                           |
+| `description` | `React.ReactNode`  | -       | Optional secondary text.                     |
+| `icon`        | `ButtonIconSpec`   | -       | Convenience icon shortcut.                   |
+| `leading`     | `React.ReactNode`  | -       | Custom leading content. Overrides `icon`.    |
+| `trailing`    | `React.ReactNode`  | -       | Custom trailing content.                     |
+| `intent`      | `MenuActionIntent` | -       | Action intent, currently `default`/`danger`. |
+| `disabled`    | `boolean`          | `false` | Disables the action.                         |
+| `selected`    | `boolean`          | `false` | Marks the action as selected.                |
+| `onPress`     | `() => void`       | -       | Called when the action is selected.          |
+
+`ActionSheet` props:
+
+| Prop              | Type              | Default    | Notes                                      |
+| ----------------- | ----------------- | ---------- | ------------------------------------------ |
+| `visible`         | `boolean`         | -          | Controls sheet visibility.                 |
+| `onDismiss`       | `() => void`      | -          | Called when the sheet is dismissed.        |
+| `title`           | `React.ReactNode` | -          | Optional sheet title.                      |
+| `description`     | `React.ReactNode` | -          | Optional sheet description.                |
+| `children`        | `React.ReactNode` | -          | Usually `ActionSheetItem` children.        |
+| `cancelLabel`     | `React.ReactNode` | `'Cancel'` | Label for the cancel action.               |
+| `closeOnBackdrop` | `boolean`         | `true`     | Dismisses the sheet when backdrop pressed. |
+| `testID`          | `string`          | -          | Test id.                                   |
+| `mode`            | `ZoraThemeMode`   | -          | Optional scoped theme mode override.       |
+| `themeId`         | `ZoraThemeId`     | -          | Optional scoped theme id override.         |
+
+`ActionSheetItem` props:
+
+| Prop          | Type              | Default | Notes                                     |
+| ------------- | ----------------- | ------- | ----------------------------------------- |
+| `label`       | `React.ReactNode` | -       | Main action label.                        |
+| `description` | `React.ReactNode` | -       | Optional secondary text.                  |
+| `icon`        | `ButtonIconSpec`  | -       | Convenience icon shortcut.                |
+| `leading`     | `React.ReactNode` | -       | Custom leading content. Overrides `icon`. |
+| `trailing`    | `React.ReactNode` | -       | Custom trailing content.                  |
+| `color`       | `ZoraColor`       | -       | Semantic action color.                    |
+| `disabled`    | `boolean`         | `false` | Disables the action.                      |
+| `selected`    | `boolean`         | `false` | Marks the action as selected.             |
+| `onPress`     | `() => void`      | -       | Called when the item is pressed.          |
+| `testID`      | `string`          | -       | Test id.                                  |
+| `mode`        | `ZoraThemeMode`   | -       | Optional scoped theme mode override.      |
+| `themeId`     | `ZoraThemeId`     | -       | Optional scoped theme id override.        |
+
+Type aliases:
+
+```ts
+type DropdownMenuProps = MenuProps;
+type MenuActionIntent = 'default' | 'danger';
+```
+
+Inherited behavior:
+
+- `Menu` / `DropdownMenu` are backed by Surface `Menu`.
+- `ActionSheet` / `ActionSheetItem` are backed by Surface `ActionSheet`.
+- ZORA adds app-facing naming, icon shortcuts, public exports, metadata, and
+  theme scoping.
 
 </details>
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@ankhorage/color-theory": "^0.0.7",
         "@ankhorage/contracts": "^1.7.0",
-        "@ankhorage/surface": "^2.0.1",
+        "@ankhorage/surface": "^2.0.2",
       },
       "devDependencies": {
         "@ankhorage/devtools": "^1.0.6",
@@ -42,7 +42,7 @@
 
     "@ankhorage/devtools": ["@ankhorage/devtools@1.0.6", "", { "dependencies": { "@eslint/js": "^10.0.1", "eslint": "^10.2.0", "eslint-config-prettier": "^10.1.8", "eslint-plugin-import": "^2.32.0", "eslint-plugin-prettier": "^5.5.5", "eslint-plugin-simple-import-sort": "^12.1.1", "eslint-plugin-unused-imports": "^4.4.1", "knip": "^6.12.2", "prettier": "^3.8.1", "typescript-eslint": "^8.24.0" }, "bin": { "ankhorage-eslint": "dist/eslint-cli.js", "ankhorage-knip": "dist/knip-cli.js", "ankhorage-prettier": "dist/prettier-cli.js" } }, "sha512-QXvpJ3uvr3xcl/smjv0yMimtGRCt/dPs0lVdHYMAXg06u1HsZmoKhRyxdFX8OXcCv9RnfPNheUkjAbOrs0eeaQ=="],
 
-    "@ankhorage/surface": ["@ankhorage/surface@2.0.1", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7", "@ankhorage/contracts": "^1.7.0" }, "peerDependencies": { "@expo/vector-icons": ">=14.0.0", "expo-font": "^55.0.6", "react": ">=18.2.0", "react-native": ">=0.72.0", "react-native-safe-area-context": "^5.0.0" }, "optionalPeers": ["@expo/vector-icons", "expo-font"] }, "sha512-ghZvuiiC27XOjZH/aor5Wcg1Pol0BNcWKBmW5sCvBVkLwkAn+OyGfJ0UbuedkQ0BIYJ7sWS1rl5BY3FV+DutGg=="],
+    "@ankhorage/surface": ["@ankhorage/surface@2.0.2", "", { "dependencies": { "@ankhorage/color-theory": "^0.0.7", "@ankhorage/contracts": "^1.7.0" }, "peerDependencies": { "@expo/vector-icons": ">=14.0.0", "expo-font": "^55.0.6", "react": ">=18.2.0", "react-native": ">=0.72.0", "react-native-safe-area-context": "^5.0.0" }, "optionalPeers": ["@expo/vector-icons", "expo-font"] }, "sha512-mqWxud3bFEezlrtYselveqrhEI9olgGMNHv35iI/pvzZP+oPqIwKSl5JzV7CTrbzp+YhHZVNzAzYEMtdhiD5QA=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@ankhorage/color-theory": "^0.0.7",
     "@ankhorage/contracts": "^1.7.0",
-    "@ankhorage/surface": "^2.0.1"
+    "@ankhorage/surface": "^2.0.2"
   },
   "files": [
     "dist",

--- a/src/components/action-sheet/ActionSheet.tsx
+++ b/src/components/action-sheet/ActionSheet.tsx
@@ -1,0 +1,11 @@
+import { ActionSheet as SurfaceActionSheet } from '@ankhorage/surface';
+import React from 'react';
+
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import type { ActionSheetProps } from './types';
+
+function ActionSheetInner({ mode: _mode, themeId: _themeId, ...props }: ActionSheetProps) {
+  return <SurfaceActionSheet {...props} />;
+}
+
+export const ActionSheet = withZoraThemeScope(ActionSheetInner);

--- a/src/components/action-sheet/ActionSheetItem.tsx
+++ b/src/components/action-sheet/ActionSheetItem.tsx
@@ -1,0 +1,32 @@
+import { ActionSheetItem as SurfaceActionSheetItem } from '@ankhorage/surface';
+import React from 'react';
+
+import { resolveIconSize } from '../../internal/recipes';
+import { useZoraTheme } from '../../theme/useZoraTheme';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import { Icon } from '../icon';
+import type { ActionSheetItemProps } from './types';
+
+function ActionSheetItemInner({
+  themeId: _themeId,
+  mode: _mode,
+  icon,
+  leading,
+  ...props
+}: ActionSheetItemProps) {
+  const { theme } = useZoraTheme();
+  const resolvedLeading =
+    leading ??
+    (icon ? (
+      <Icon
+        color={theme.semantics.content.muted}
+        name={icon.name}
+        provider={icon.provider}
+        size={resolveIconSize('s')}
+      />
+    ) : undefined);
+
+  return <SurfaceActionSheetItem {...props} leading={resolvedLeading} />;
+}
+
+export const ActionSheetItem = withZoraThemeScope(ActionSheetItemInner);

--- a/src/components/action-sheet/index.ts
+++ b/src/components/action-sheet/index.ts
@@ -1,0 +1,3 @@
+export { ActionSheet } from './ActionSheet';
+export { ActionSheetItem } from './ActionSheetItem';
+export type { ActionSheetItemProps, ActionSheetProps } from './types';

--- a/src/components/action-sheet/meta.ts
+++ b/src/components/action-sheet/meta.ts
@@ -1,0 +1,19 @@
+import type { ZoraComponentMeta } from '../../metadata';
+
+export const actionSheetMeta = {
+  name: 'ActionSheet',
+  category: 'component',
+  directManifestNode: false,
+  allowedChildren: [],
+  note: 'Surface-backed contextual action sheet; not represented as a manifest node in v1.',
+  props: {},
+} as const satisfies ZoraComponentMeta;
+
+export const actionSheetItemMeta = {
+  name: 'ActionSheetItem',
+  category: 'component',
+  directManifestNode: false,
+  allowedChildren: [],
+  note: 'Surface-backed contextual action sheet row; not represented as a manifest node in v1.',
+  props: {},
+} as const satisfies ZoraComponentMeta;

--- a/src/components/action-sheet/types.ts
+++ b/src/components/action-sheet/types.ts
@@ -1,0 +1,23 @@
+import type {
+  ActionSheetItemProps as SurfaceActionSheetItemProps,
+  ActionSheetProps as SurfaceActionSheetProps,
+  ButtonIconSpec,
+} from '@ankhorage/surface';
+import type React from 'react';
+
+import type { ZoraColor } from '../../internal/recipes';
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export interface ActionSheetProps
+  extends ZoraBaseProps,
+    Omit<SurfaceActionSheetProps, 'children' | 'mode' | 'themeId'> {
+  children?: React.ReactNode;
+}
+
+export interface ActionSheetItemProps
+  extends ZoraBaseProps,
+    Omit<SurfaceActionSheetItemProps, 'color' | 'leading' | 'mode' | 'themeId'> {
+  color?: ZoraColor;
+  icon?: ButtonIconSpec;
+  leading?: React.ReactNode;
+}

--- a/src/components/action-sheet/types.ts
+++ b/src/components/action-sheet/types.ts
@@ -9,13 +9,13 @@ import type { ZoraColor } from '../../internal/recipes';
 import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 
 export interface ActionSheetProps
-  extends ZoraBaseProps,
-    Omit<SurfaceActionSheetProps, 'children' | 'mode' | 'themeId'> {
+  extends ZoraBaseProps, Omit<SurfaceActionSheetProps, 'children' | 'mode' | 'themeId'> {
   children?: React.ReactNode;
 }
 
 export interface ActionSheetItemProps
-  extends ZoraBaseProps,
+  extends
+    ZoraBaseProps,
     Omit<SurfaceActionSheetItemProps, 'color' | 'leading' | 'mode' | 'themeId'> {
   color?: ZoraColor;
   icon?: ButtonIconSpec;

--- a/src/components/menu/DropdownMenu.tsx
+++ b/src/components/menu/DropdownMenu.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+
+import { Menu } from './Menu';
+import type { DropdownMenuProps } from './types';
+
+export function DropdownMenu(props: DropdownMenuProps) {
+  return <Menu {...props} />;
+}

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -1,12 +1,11 @@
 import { Menu as SurfaceMenu, type MenuAction as SurfaceMenuAction } from '@ankhorage/surface';
 import React, { useMemo } from 'react';
 
-import { Box, Inline, Stack } from '../../foundation';
+import { Box } from '../../foundation';
 import { resolveIconSize } from '../../internal/recipes';
 import { useZoraTheme } from '../../theme/useZoraTheme';
 import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
 import { Icon } from '../icon';
-import { Text } from '../text';
 import type { MenuAction, MenuProps } from './types';
 
 function renderActionLeading(action: MenuAction, iconColor: string) {
@@ -28,21 +27,6 @@ function renderActionLeading(action: MenuAction, iconColor: string) {
   );
 }
 
-function renderActionTitle(action: MenuAction) {
-  return (
-    <Stack gap="xxs">
-      <Text variant="bodySmall" weight={action.selected ? 'semiBold' : 'medium'}>
-        {action.title}
-      </Text>
-      {action.description ? (
-        <Text emphasis="muted" variant="caption">
-          {action.description}
-        </Text>
-      ) : null}
-    </Stack>
-  );
-}
-
 function renderActionTrailing(action: MenuAction) {
   if (!action.trailing) {
     return undefined;
@@ -54,13 +38,13 @@ function renderActionTrailing(action: MenuAction) {
 function toSurfaceAction(action: MenuAction, iconColor: string): SurfaceMenuAction {
   return {
     activate: action.onPress,
-    description: undefined,
+    description: action.description,
     disabled: action.disabled,
     id: action.id,
     intent: action.intent,
     leading: renderActionLeading(action, iconColor),
     selected: action.selected,
-    title: renderActionTitle(action),
+    title: action.title,
     trailing: renderActionTrailing(action),
   };
 }

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -49,13 +49,7 @@ function toSurfaceAction(action: MenuAction, iconColor: string): SurfaceMenuActi
   };
 }
 
-function MenuInner({
-  themeId: _themeId,
-  mode: _mode,
-  actions,
-  onDismiss,
-  ...props
-}: MenuProps) {
+function MenuInner({ themeId: _themeId, mode: _mode, actions, onDismiss, ...props }: MenuProps) {
   const { theme } = useZoraTheme();
   const iconColor = theme.semantics.content.muted;
   const surfaceActions = useMemo(

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -1,0 +1,86 @@
+import { Menu as SurfaceMenu, type MenuAction as SurfaceMenuAction } from '@ankhorage/surface';
+import React, { useMemo } from 'react';
+
+import { Box, Inline, Stack } from '../../foundation';
+import { resolveIconSize } from '../../internal/recipes';
+import { useZoraTheme } from '../../theme/useZoraTheme';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import { Icon } from '../icon';
+import { Text } from '../text';
+import type { MenuAction, MenuProps } from './types';
+
+function renderActionLeading(action: MenuAction, iconColor: string) {
+  if (action.leading) {
+    return action.leading;
+  }
+
+  if (!action.icon) {
+    return undefined;
+  }
+
+  return (
+    <Icon
+      color={iconColor}
+      name={action.icon.name}
+      provider={action.icon.provider}
+      size={resolveIconSize('s')}
+    />
+  );
+}
+
+function renderActionTitle(action: MenuAction) {
+  return (
+    <Stack gap="xxs">
+      <Text variant="bodySmall" weight={action.selected ? 'semiBold' : 'medium'}>
+        {action.title}
+      </Text>
+      {action.description ? (
+        <Text emphasis="muted" variant="caption">
+          {action.description}
+        </Text>
+      ) : null}
+    </Stack>
+  );
+}
+
+function renderActionTrailing(action: MenuAction) {
+  if (!action.trailing) {
+    return undefined;
+  }
+
+  return <Box>{action.trailing}</Box>;
+}
+
+function toSurfaceAction(action: MenuAction, iconColor: string): SurfaceMenuAction {
+  return {
+    activate: action.onPress,
+    description: undefined,
+    disabled: action.disabled,
+    id: action.id,
+    intent: action.intent,
+    leading: renderActionLeading(action, iconColor),
+    selected: action.selected,
+    title: renderActionTitle(action),
+    trailing: renderActionTrailing(action),
+  };
+}
+
+function MenuInner({
+  themeId: _themeId,
+  mode: _mode,
+  actions,
+  onDismiss,
+  ...props
+}: MenuProps) {
+  const { theme } = useZoraTheme();
+  const iconColor = theme.semantics.content.muted;
+  const surfaceActions = useMemo(
+    () => actions.map((action) => toSurfaceAction(action, iconColor)),
+    [actions, iconColor],
+  );
+
+  return <SurfaceMenu {...props} actions={surfaceActions} dismiss={onDismiss} />;
+}
+
+export const Menu = withZoraThemeScope(MenuInner);
+export const DropdownMenu = Menu;

--- a/src/components/menu/Menu.tsx
+++ b/src/components/menu/Menu.tsx
@@ -61,4 +61,3 @@ function MenuInner({ themeId: _themeId, mode: _mode, actions, onDismiss, ...prop
 }
 
 export const Menu = withZoraThemeScope(MenuInner);
-export const DropdownMenu = Menu;

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -1,0 +1,2 @@
+export { DropdownMenu, Menu } from './Menu';
+export type { DropdownMenuProps, MenuAction, MenuActionIntent, MenuProps } from './types';

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -1,2 +1,3 @@
-export { DropdownMenu, Menu } from './Menu';
+export { DropdownMenu } from './DropdownMenu';
+export { Menu } from './Menu';
 export type { DropdownMenuProps, MenuAction, MenuActionIntent, MenuProps } from './types';

--- a/src/components/menu/meta.ts
+++ b/src/components/menu/meta.ts
@@ -1,0 +1,19 @@
+import type { ZoraComponentMeta } from '../../metadata';
+
+export const menuMeta = {
+  name: 'Menu',
+  category: 'component',
+  directManifestNode: false,
+  allowedChildren: [],
+  note: 'Surface-backed action menu; not represented as a manifest node in v1.',
+  props: {},
+} as const satisfies ZoraComponentMeta;
+
+export const dropdownMenuMeta = {
+  name: 'DropdownMenu',
+  category: 'component',
+  directManifestNode: false,
+  allowedChildren: [],
+  note: 'Product-facing alias for Menu trigger/action composition; not represented as a manifest node in v1.',
+  props: {},
+} as const satisfies ZoraComponentMeta;

--- a/src/components/menu/types.ts
+++ b/src/components/menu/types.ts
@@ -23,8 +23,7 @@ export interface MenuAction {
 }
 
 export interface MenuProps
-  extends ZoraBaseProps,
-    Omit<SurfaceMenuProps, 'actions' | 'dismiss' | 'mode' | 'themeId'> {
+  extends ZoraBaseProps, Omit<SurfaceMenuProps, 'actions' | 'dismiss' | 'mode' | 'themeId'> {
   actions: readonly MenuAction[];
   onDismiss?: () => void;
 }

--- a/src/components/menu/types.ts
+++ b/src/components/menu/types.ts
@@ -1,0 +1,32 @@
+import type {
+  ButtonIconSpec,
+  MenuActionIntent as SurfaceMenuActionIntent,
+  MenuProps as SurfaceMenuProps,
+} from '@ankhorage/surface';
+import type React from 'react';
+
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export type MenuActionIntent = SurfaceMenuActionIntent;
+
+export interface MenuAction {
+  id: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  icon?: ButtonIconSpec;
+  leading?: React.ReactNode;
+  trailing?: React.ReactNode;
+  intent?: MenuActionIntent;
+  disabled?: boolean;
+  selected?: boolean;
+  onPress?: () => void;
+}
+
+export interface MenuProps
+  extends ZoraBaseProps,
+    Omit<SurfaceMenuProps, 'actions' | 'dismiss' | 'mode' | 'themeId'> {
+  actions: readonly MenuAction[];
+  onDismiss?: () => void;
+}
+
+export type DropdownMenuProps = MenuProps;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+export type { ActionSheetItemProps, ActionSheetProps } from './components/action-sheet';
+export { ActionSheet, ActionSheetItem } from './components/action-sheet';
 export type { AppBarMode, AppBarOverflowAction, AppBarProps } from './components/app-bar';
 export { AppBar } from './components/app-bar';
 export type { AvatarProps, AvatarShape, AvatarSize } from './components/avatar';
@@ -76,6 +78,13 @@ export type { MetricCardProps } from './components/metric-card';
 export { MetricCard } from './components/metric-card';
 export type { ModalProps } from './components/modal';
 export { Modal } from './components/modal';
+export type {
+  DropdownMenuProps,
+  MenuAction,
+  MenuActionIntent,
+  MenuProps,
+} from './components/menu';
+export { DropdownMenu, Menu } from './components/menu';
 export type {
   NavigationItemProps,
   ZoraNavigationRouteMetadata,

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,17 +74,12 @@ export type { InputProps, InputTrailingAction } from './components/input';
 export { Input } from './components/input';
 export type { MediaCardImageProps, MediaCardProps } from './components/media-card';
 export { MediaCard } from './components/media-card';
+export type { DropdownMenuProps, MenuAction, MenuActionIntent, MenuProps } from './components/menu';
+export { DropdownMenu, Menu } from './components/menu';
 export type { MetricCardProps } from './components/metric-card';
 export { MetricCard } from './components/metric-card';
 export type { ModalProps } from './components/modal';
 export { Modal } from './components/modal';
-export type {
-  DropdownMenuProps,
-  MenuAction,
-  MenuActionIntent,
-  MenuProps,
-} from './components/menu';
-export { DropdownMenu, Menu } from './components/menu';
 export type {
   NavigationItemProps,
   ZoraNavigationRouteMetadata,

--- a/src/metadata/componentMeta.ts
+++ b/src/metadata/componentMeta.ts
@@ -1,3 +1,4 @@
+import { actionSheetItemMeta, actionSheetMeta } from '../components/action-sheet/meta';
 import { appBarMeta } from '../components/app-bar/meta';
 import { avatarMeta } from '../components/avatar/meta';
 import { avatarGroupMeta } from '../components/avatar-group/meta';
@@ -16,6 +17,7 @@ import { iconButtonMeta } from '../components/icon-button/meta';
 import { imageMeta } from '../components/image/meta';
 import { inputMeta } from '../components/input/meta';
 import { mediaCardMeta } from '../components/media-card/meta';
+import { menuMeta, dropdownMenuMeta } from '../components/menu/meta';
 import { metricCardMeta } from '../components/metric-card/meta';
 import { modalMeta } from '../components/modal/meta';
 import { navigationItemMeta } from '../components/navigation-item/meta';
@@ -79,6 +81,8 @@ import type { ZoraComponentMetaRegistry } from './types';
 
 export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   ...foundationMetas,
+  ActionSheet: actionSheetMeta,
+  ActionSheetItem: actionSheetItemMeta,
   AppBar: appBarMeta,
   Avatar: avatarMeta,
   AvatarGroup: avatarGroupMeta,
@@ -91,6 +95,7 @@ export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   Chip: chipMeta,
   ChipGroup: chipGroupMeta,
   Drawer: drawerMeta,
+  DropdownMenu: dropdownMenuMeta,
   Form: formMeta,
   FormActions: formActionsMeta,
   FormError: formErrorMeta,
@@ -101,6 +106,7 @@ export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   Image: imageMeta,
   Input: inputMeta,
   MediaCard: mediaCardMeta,
+  Menu: menuMeta,
   MetricCard: metricCardMeta,
   Modal: modalMeta,
   NavigationItem: navigationItemMeta,

--- a/src/metadata/componentMeta.ts
+++ b/src/metadata/componentMeta.ts
@@ -17,7 +17,7 @@ import { iconButtonMeta } from '../components/icon-button/meta';
 import { imageMeta } from '../components/image/meta';
 import { inputMeta } from '../components/input/meta';
 import { mediaCardMeta } from '../components/media-card/meta';
-import { menuMeta, dropdownMenuMeta } from '../components/menu/meta';
+import { dropdownMenuMeta, menuMeta } from '../components/menu/meta';
 import { metricCardMeta } from '../components/metric-card/meta';
 import { modalMeta } from '../components/modal/meta';
 import { navigationItemMeta } from '../components/navigation-item/meta';


### PR DESCRIPTION
## Summary

- expose Surface-backed `Menu` and `DropdownMenu` from `@ankhorage/zora`
- expose Surface-backed `ActionSheet` and `ActionSheetItem` from `@ankhorage/zora`
- add ZORA app-facing action item types with `icon`, `onPress`, and `onDismiss` naming while mapping to Surface `leading`, `activate`, and `dismiss`
- register `Menu`, `DropdownMenu`, `ActionSheet`, and `ActionSheetItem` in `ZORA_COMPONENT_META`
- export all new components and public types from the root barrel
- document the new action surfaces in the README component list and component section
- bump `@ankhorage/surface` to `^2.0.2` for the released `MenuAction` API
- add a patch changeset

Closes #205.

## Surface / ZORA boundary

Surface remains the source of truth for low-level action surface mechanics:

- `Menu` trigger measurement, portal rendering, keyboard navigation, focus scope, escape handling, outside dismissal, and close-on-select behavior
- `ActionSheet` overlay, backdrop dismissal, focus/accessibility behavior, and action row rendering

ZORA adds app-facing semantics and convenience:

- `DropdownMenu` naming as a product-facing wrapper over `Menu`
- `MenuAction.icon` shortcut that renders a ZORA `Icon`
- `MenuAction.onPress` mapped to Surface `activate`
- `MenuProps.onDismiss` mapped to Surface `dismiss`
- `ActionSheetItem.icon` shortcut that renders a ZORA `Icon`
- ZORA theme scoping via `mode` / `themeId`

## Notes

The wrappers intentionally do not duplicate Surface menu or sheet internals. Surface renders the structured menu and action sheet rows; ZORA only maps app-facing action specs into Surface primitives.

`DropdownMenu` is implemented as its own wrapper component instead of a direct alias so public exports stay knip-clean.

## Verification

Not run locally in this environment because the connected GitHub API path cannot execute repo commands. Please run before merge:

```bash
bun install
bun run knip
bun run lint
bun run build
bun run test
```