### PR TITLE
feat: add DataTable component

### DIFF
--- a/.changeset/data-table.md
+++ b/.changeset/data-table.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Add DataTable for typed app-facing tabular data with row actions, sorting state, loading, empty, and responsive layouts.

--- a/src/components/data-table/DataTable.tsx
+++ b/src/components/data-table/DataTable.tsx
@@ -77,11 +77,15 @@ function renderDefaultCell(value: unknown): React.ReactNode {
     return String(value);
   }
 
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
   if (value instanceof Date) {
     return value.toLocaleDateString();
   }
 
-  return String(value);
+  return '—';
 }
 
 function createCellContext<TRow extends object>(

--- a/src/components/data-table/DataTable.tsx
+++ b/src/components/data-table/DataTable.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
 import { ScrollView, type ViewStyle } from 'react-native';
 
+import { Box, Show, Stack } from '../../foundation';
+import { EmptyState } from '../../patterns/empty-state';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import { Button } from '../button';
 import { Card } from '../card';
 import { IconButton } from '../icon-button';
 import { DropdownMenu, type MenuAction } from '../menu';
 import { SkeletonList } from '../skeleton';
 import { Text, type TextAlign } from '../text';
-import { Box, Show, Stack } from '../../foundation';
-import { EmptyState } from '../../patterns/empty-state';
-import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
 import type {
   DataTableCellContext,
   DataTableColumn,
   DataTableColumnAlign,
+  DataTableDensity,
   DataTableProps,
   DataTableRowAction,
   DataTableSortDirection,
@@ -52,7 +54,7 @@ function resolveCellStyle<TRow extends object>(column: DataTableColumn<TRow>): V
   };
 }
 
-function resolveRowPadding(density: NonNullable<DataTableProps<object>['density']>) {
+function resolveRowPadding(density: DataTableDensity) {
   return density === 'compact' ? { px: 'm' as const, py: 's' as const } : { px: 'm' as const, py: 'm' as const };
 }
 
@@ -80,20 +82,42 @@ function renderDefaultCell(value: unknown): React.ReactNode {
   return String(value);
 }
 
+function createCellContext<TRow extends object>(
+  column: DataTableColumn<TRow>,
+  row: TRow,
+  rowIndex: number,
+): DataTableCellContext<TRow> {
+  return {
+    column,
+    row,
+    rowIndex,
+    value: resolveAccessorValue(row, column),
+  };
+}
+
 function renderCell<TRow extends object>(
   column: DataTableColumn<TRow>,
   row: TRow,
   rowIndex: number,
 ) {
-  const value = resolveAccessorValue(row, column);
-  const context: DataTableCellContext<TRow> = {
-    column,
-    row,
-    rowIndex,
-    value,
-  };
+  const context = createCellContext(column, row, rowIndex);
+  return column.renderCell ? column.renderCell(context) : renderDefaultCell(context.value);
+}
 
-  return column.renderCell ? column.renderCell(context) : renderDefaultCell(value);
+function renderTableCell<TRow extends object>(
+  column: DataTableColumn<TRow>,
+  row: TRow,
+  rowIndex: number,
+) {
+  if (column.renderCell) {
+    return column.renderCell(createCellContext(column, row, rowIndex));
+  }
+
+  return (
+    <Text align={resolveTextAlign(column.align)} variant="bodySmall">
+      {renderDefaultCell(resolveAccessorValue(row, column))}
+    </Text>
+  );
 }
 
 function resolveNextSortDirection(
@@ -164,14 +188,12 @@ function DataTableHeader<TRow extends object>({
         {columns.map((column) => {
           const currentDirection = sort?.columnId === column.id ? sort.direction : undefined;
           const sortable = Boolean(column.sortable && onSortChange);
-          const label = currentDirection ? `${column.header} ${currentDirection === 'asc' ? '↑' : '↓'}` : column.header;
+          const directionLabel = currentDirection === undefined ? '' : currentDirection === 'asc' ? ' ↑' : ' ↓';
 
           return (
             <Box key={column.id} px={padding.px} py={padding.py} style={resolveCellStyle(column)}>
               {sortable ? (
-                <Text
-                  accessibilityRole="button"
-                  align={resolveTextAlign(column.align)}
+                <Button
                   color="primary"
                   onPress={() =>
                     onSortChange?.({
@@ -179,11 +201,12 @@ function DataTableHeader<TRow extends object>({
                       direction: resolveNextSortDirection(currentDirection),
                     })
                   }
-                  variant="caption"
-                  weight="semiBold"
+                  size="s"
+                  variant="ghost"
                 >
-                  {label}
-                </Text>
+                  {column.header}
+                  {directionLabel}
+                </Button>
               ) : (
                 <Text align={resolveTextAlign(column.align)} emphasis="muted" variant="caption" weight="semiBold">
                   {column.header}
@@ -232,9 +255,7 @@ function DataTableDesktop<TRow extends object>({
                 <Stack direction="row" align="center">
                   {columns.map((column) => (
                     <Box key={column.id} px={padding.px} py={padding.py} style={resolveCellStyle(column)}>
-                      <Text align={resolveTextAlign(column.align)} variant="bodySmall">
-                        {renderCell(column, row, rowIndex)}
-                      </Text>
+                      {renderTableCell(column, row, rowIndex)}
                     </Box>
                   ))}
                   <Box px={padding.px} py={padding.py} style={{ alignItems: 'flex-end', minWidth: 56, width: 56 }}>
@@ -279,7 +300,11 @@ function DataTableMobile<TRow extends object>({
                   <Text emphasis="muted" variant="caption" weight="semiBold">
                     {column.header}
                   </Text>
-                  <Text variant="bodySmall">{renderCell(column, row, rowIndex)}</Text>
+                  {column.renderCell ? (
+                    renderCell(column, row, rowIndex)
+                  ) : (
+                    <Text variant="bodySmall">{renderDefaultCell(resolveAccessorValue(row, column))}</Text>
+                  )}
                 </Stack>
               ))}
             </Stack>
@@ -307,7 +332,7 @@ function DataTableInner<TRow extends object>({
   }
 
   if (rows.length === 0) {
-    return <EmptyState compact title={emptyTitle} description={emptyDescription} testID={testID} />;
+    return <EmptyState title={emptyTitle} description={emptyDescription} />;
   }
 
   const tableProps: DataTableProps<TRow> = {

--- a/src/components/data-table/DataTable.tsx
+++ b/src/components/data-table/DataTable.tsx
@@ -55,7 +55,9 @@ function resolveCellStyle<TRow extends object>(column: DataTableColumn<TRow>): V
 }
 
 function resolveRowPadding(density: DataTableDensity) {
-  return density === 'compact' ? { px: 'm' as const, py: 's' as const } : { px: 'm' as const, py: 'm' as const };
+  return density === 'compact'
+    ? { px: 'm' as const, py: 's' as const }
+    : { px: 'm' as const, py: 'm' as const };
 }
 
 function resolveAccessorValue<TRow extends object>(row: TRow, column: DataTableColumn<TRow>) {
@@ -188,7 +190,8 @@ function DataTableHeader<TRow extends object>({
         {columns.map((column) => {
           const currentDirection = sort?.columnId === column.id ? sort.direction : undefined;
           const sortable = Boolean(column.sortable && onSortChange);
-          const directionLabel = currentDirection === undefined ? '' : currentDirection === 'asc' ? ' ↑' : ' ↓';
+          const directionLabel =
+            currentDirection === undefined ? '' : currentDirection === 'asc' ? ' ↑' : ' ↓';
 
           return (
             <Box key={column.id} px={padding.px} py={padding.py} style={resolveCellStyle(column)}>
@@ -208,7 +211,12 @@ function DataTableHeader<TRow extends object>({
                   {directionLabel}
                 </Button>
               ) : (
-                <Text align={resolveTextAlign(column.align)} emphasis="muted" variant="caption" weight="semiBold">
+                <Text
+                  align={resolveTextAlign(column.align)}
+                  emphasis="muted"
+                  variant="caption"
+                  weight="semiBold"
+                >
                   {column.header}
                 </Text>
               )}
@@ -241,7 +249,12 @@ function DataTableDesktop<TRow extends object>({
     <ScrollView horizontal showsHorizontalScrollIndicator={false}>
       <Box minWidth={720} style={{ width: '100%' }}>
         <Stack gap="xs">
-          <DataTableHeader columns={columns} density={density} onSortChange={onSortChange} sort={sort} />
+          <DataTableHeader
+            columns={columns}
+            density={density}
+            onSortChange={onSortChange}
+            sort={sort}
+          />
           <Stack gap="xs">
             {rows.map((row, rowIndex) => (
               <Box
@@ -254,11 +267,20 @@ function DataTableDesktop<TRow extends object>({
               >
                 <Stack direction="row" align="center">
                   {columns.map((column) => (
-                    <Box key={column.id} px={padding.px} py={padding.py} style={resolveCellStyle(column)}>
+                    <Box
+                      key={column.id}
+                      px={padding.px}
+                      py={padding.py}
+                      style={resolveCellStyle(column)}
+                    >
                       {renderTableCell(column, row, rowIndex)}
                     </Box>
                   ))}
-                  <Box px={padding.px} py={padding.py} style={{ alignItems: 'flex-end', minWidth: 56, width: 56 }}>
+                  <Box
+                    px={padding.px}
+                    py={padding.py}
+                    style={{ alignItems: 'flex-end', minWidth: 56, width: 56 }}
+                  >
                     {renderRowActions({ row, rowActions, rowIndex, testID })}
                   </Box>
                 </Stack>
@@ -283,7 +305,9 @@ function DataTableMobile<TRow extends object>({
   return (
     <Stack gap="s">
       {rows.map((row, rowIndex) => {
-        const title = primaryColumn ? renderCell(primaryColumn, row, rowIndex) : `Row ${rowIndex + 1}`;
+        const title = primaryColumn
+          ? renderCell(primaryColumn, row, rowIndex)
+          : `Row ${rowIndex + 1}`;
         const actions = renderRowActions({ row, rowActions, rowIndex, testID });
 
         return (
@@ -303,7 +327,9 @@ function DataTableMobile<TRow extends object>({
                   {column.renderCell ? (
                     renderCell(column, row, rowIndex)
                   ) : (
-                    <Text variant="bodySmall">{renderDefaultCell(resolveAccessorValue(row, column))}</Text>
+                    <Text variant="bodySmall">
+                      {renderDefaultCell(resolveAccessorValue(row, column))}
+                    </Text>
                   )}
                 </Stack>
               ))}

--- a/src/components/data-table/DataTable.tsx
+++ b/src/components/data-table/DataTable.tsx
@@ -1,0 +1,333 @@
+import React from 'react';
+import { ScrollView, type ViewStyle } from 'react-native';
+
+import { Card } from '../card';
+import { IconButton } from '../icon-button';
+import { DropdownMenu, type MenuAction } from '../menu';
+import { SkeletonList } from '../skeleton';
+import { Text, type TextAlign } from '../text';
+import { Box, Show, Stack } from '../../foundation';
+import { EmptyState } from '../../patterns/empty-state';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import type {
+  DataTableCellContext,
+  DataTableColumn,
+  DataTableColumnAlign,
+  DataTableProps,
+  DataTableRowAction,
+  DataTableSortDirection,
+} from './types';
+
+function resolveTextAlign(align: DataTableColumnAlign | undefined): TextAlign {
+  switch (align) {
+    case 'center':
+      return 'center';
+    case 'end':
+      return 'right';
+    case 'start':
+    default:
+      return 'left';
+  }
+}
+
+function resolveCellJustify(align: DataTableColumnAlign | undefined): ViewStyle['alignItems'] {
+  switch (align) {
+    case 'center':
+      return 'center';
+    case 'end':
+      return 'flex-end';
+    case 'start':
+    default:
+      return 'flex-start';
+  }
+}
+
+function resolveCellStyle<TRow extends object>(column: DataTableColumn<TRow>): ViewStyle {
+  return {
+    alignItems: resolveCellJustify(column.align),
+    flexGrow: column.width === undefined ? 1 : 0,
+    flexShrink: 0,
+    minWidth: column.minWidth ?? 140,
+    width: column.width,
+  };
+}
+
+function resolveRowPadding(density: NonNullable<DataTableProps<object>['density']>) {
+  return density === 'compact' ? { px: 'm' as const, py: 's' as const } : { px: 'm' as const, py: 'm' as const };
+}
+
+function resolveAccessorValue<TRow extends object>(row: TRow, column: DataTableColumn<TRow>) {
+  if (column.accessor === undefined) {
+    return undefined;
+  }
+
+  return row[column.accessor];
+}
+
+function renderDefaultCell(value: unknown): React.ReactNode {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (value instanceof Date) {
+    return value.toLocaleDateString();
+  }
+
+  return String(value);
+}
+
+function renderCell<TRow extends object>(
+  column: DataTableColumn<TRow>,
+  row: TRow,
+  rowIndex: number,
+) {
+  const value = resolveAccessorValue(row, column);
+  const context: DataTableCellContext<TRow> = {
+    column,
+    row,
+    rowIndex,
+    value,
+  };
+
+  return column.renderCell ? column.renderCell(context) : renderDefaultCell(value);
+}
+
+function resolveNextSortDirection(
+  current: DataTableSortDirection | undefined,
+): DataTableSortDirection {
+  return current === 'asc' ? 'desc' : 'asc';
+}
+
+function mapRowActions<TRow extends object>(
+  row: TRow,
+  actions: readonly DataTableRowAction<TRow>[],
+): readonly MenuAction[] {
+  return actions.map((action) => ({
+    description: action.description,
+    disabled: action.disabled,
+    icon: action.icon,
+    id: action.id,
+    intent: action.intent,
+    onPress: action.onPress ? () => action.onPress?.(row) : undefined,
+    title: action.title,
+  }));
+}
+
+function renderRowActions<TRow extends object>({
+  row,
+  rowIndex,
+  rowActions,
+  testID,
+}: {
+  row: TRow;
+  rowIndex: number;
+  rowActions: DataTableProps<TRow>['rowActions'];
+  testID?: string;
+}) {
+  const actions = rowActions?.(row, rowIndex) ?? [];
+
+  if (actions.length === 0) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu
+      actions={mapRowActions(row, actions)}
+      trigger={
+        <IconButton
+          icon={{ name: 'ellipsis-horizontal' }}
+          label="Row actions"
+          size="s"
+          variant="ghost"
+        />
+      }
+      testID={testID ? `${testID}-row-actions-${rowIndex}` : undefined}
+    />
+  );
+}
+
+function DataTableHeader<TRow extends object>({
+  columns,
+  sort,
+  onSortChange,
+  density,
+}: Pick<DataTableProps<TRow>, 'columns' | 'density' | 'onSortChange' | 'sort'>) {
+  const padding = resolveRowPadding(density ?? 'comfortable');
+
+  return (
+    <Box bg="subtle" borderColor="border" borderWidth={1} radius="m">
+      <Stack direction="row" align="center">
+        {columns.map((column) => {
+          const currentDirection = sort?.columnId === column.id ? sort.direction : undefined;
+          const sortable = Boolean(column.sortable && onSortChange);
+          const label = currentDirection ? `${column.header} ${currentDirection === 'asc' ? '↑' : '↓'}` : column.header;
+
+          return (
+            <Box key={column.id} px={padding.px} py={padding.py} style={resolveCellStyle(column)}>
+              {sortable ? (
+                <Text
+                  accessibilityRole="button"
+                  align={resolveTextAlign(column.align)}
+                  color="primary"
+                  onPress={() =>
+                    onSortChange?.({
+                      columnId: column.id,
+                      direction: resolveNextSortDirection(currentDirection),
+                    })
+                  }
+                  variant="caption"
+                  weight="semiBold"
+                >
+                  {label}
+                </Text>
+              ) : (
+                <Text align={resolveTextAlign(column.align)} emphasis="muted" variant="caption" weight="semiBold">
+                  {column.header}
+                </Text>
+              )}
+            </Box>
+          );
+        })}
+        <Box px={padding.px} py={padding.py} style={{ minWidth: 56, width: 56 }}>
+          <Text align="right" emphasis="muted" variant="caption" weight="semiBold">
+            Actions
+          </Text>
+        </Box>
+      </Stack>
+    </Box>
+  );
+}
+
+function DataTableDesktop<TRow extends object>({
+  columns,
+  rows,
+  rowActions,
+  rowId,
+  sort,
+  onSortChange,
+  density,
+  testID,
+}: DataTableProps<TRow>) {
+  const padding = resolveRowPadding(density ?? 'comfortable');
+
+  return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+      <Box minWidth={720} style={{ width: '100%' }}>
+        <Stack gap="xs">
+          <DataTableHeader columns={columns} density={density} onSortChange={onSortChange} sort={sort} />
+          <Stack gap="xs">
+            {rows.map((row, rowIndex) => (
+              <Box
+                bg="surface"
+                borderColor="border"
+                borderWidth={1}
+                key={rowId(row, rowIndex)}
+                radius="m"
+                testID={testID ? `${testID}-row-${rowIndex}` : undefined}
+              >
+                <Stack direction="row" align="center">
+                  {columns.map((column) => (
+                    <Box key={column.id} px={padding.px} py={padding.py} style={resolveCellStyle(column)}>
+                      <Text align={resolveTextAlign(column.align)} variant="bodySmall">
+                        {renderCell(column, row, rowIndex)}
+                      </Text>
+                    </Box>
+                  ))}
+                  <Box px={padding.px} py={padding.py} style={{ alignItems: 'flex-end', minWidth: 56, width: 56 }}>
+                    {renderRowActions({ row, rowActions, rowIndex, testID })}
+                  </Box>
+                </Stack>
+              </Box>
+            ))}
+          </Stack>
+        </Stack>
+      </Box>
+    </ScrollView>
+  );
+}
+
+function DataTableMobile<TRow extends object>({
+  columns,
+  rows,
+  rowActions,
+  rowId,
+  testID,
+}: DataTableProps<TRow>) {
+  const [primaryColumn, ...detailColumns] = columns;
+
+  return (
+    <Stack gap="s">
+      {rows.map((row, rowIndex) => {
+        const title = primaryColumn ? renderCell(primaryColumn, row, rowIndex) : `Row ${rowIndex + 1}`;
+        const actions = renderRowActions({ row, rowActions, rowIndex, testID });
+
+        return (
+          <Card
+            actions={actions}
+            compact
+            key={rowId(row, rowIndex)}
+            testID={testID ? `${testID}-card-${rowIndex}` : undefined}
+            title={title}
+          >
+            <Stack gap="s">
+              {detailColumns.map((column) => (
+                <Stack gap="xxs" key={column.id}>
+                  <Text emphasis="muted" variant="caption" weight="semiBold">
+                    {column.header}
+                  </Text>
+                  <Text variant="bodySmall">{renderCell(column, row, rowIndex)}</Text>
+                </Stack>
+              ))}
+            </Stack>
+          </Card>
+        );
+      })}
+    </Stack>
+  );
+}
+
+function DataTableInner<TRow extends object>({
+  themeId: _themeId,
+  mode: _mode,
+  rows,
+  loading = false,
+  loadingRows = 5,
+  emptyTitle = 'No data',
+  emptyDescription = 'There are no rows to display.',
+  testID,
+  density = 'comfortable',
+  ...props
+}: DataTableProps<TRow>) {
+  if (loading) {
+    return <SkeletonList rows={loadingRows} variant="card" testID={testID} />;
+  }
+
+  if (rows.length === 0) {
+    return <EmptyState compact title={emptyTitle} description={emptyDescription} testID={testID} />;
+  }
+
+  const tableProps: DataTableProps<TRow> = {
+    ...props,
+    density,
+    emptyDescription,
+    emptyTitle,
+    loading,
+    loadingRows,
+    rows,
+    testID,
+  };
+
+  return (
+    <Box testID={testID}>
+      <Show when={{ base: false, md: true }} fallback={<DataTableMobile {...tableProps} />}>
+        <DataTableDesktop {...tableProps} />
+      </Show>
+    </Box>
+  );
+}
+
+export const DataTable = withZoraThemeScope(DataTableInner);

--- a/src/components/data-table/index.ts
+++ b/src/components/data-table/index.ts
@@ -1,0 +1,11 @@
+export { DataTable } from './DataTable';
+export type {
+  DataTableCellContext,
+  DataTableColumn,
+  DataTableColumnAlign,
+  DataTableDensity,
+  DataTableProps,
+  DataTableRowAction,
+  DataTableSortDirection,
+  DataTableSortState,
+} from './types';

--- a/src/components/data-table/meta.ts
+++ b/src/components/data-table/meta.ts
@@ -1,0 +1,10 @@
+import type { ZoraComponentMeta } from '../../metadata';
+
+export const dataTableMeta = {
+  name: 'DataTable',
+  category: 'component',
+  directManifestNode: false,
+  allowedChildren: [],
+  note: 'Code-facing typed data table component; not represented as a manifest node in v1.',
+  props: {},
+} as const satisfies ZoraComponentMeta;

--- a/src/components/data-table/types.ts
+++ b/src/components/data-table/types.ts
@@ -1,0 +1,57 @@
+import type { ButtonIconSpec } from '@ankhorage/surface';
+import type React from 'react';
+
+import type { MenuActionIntent } from '../menu';
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export type DataTableColumnAlign = 'start' | 'center' | 'end';
+export type DataTableDensity = 'comfortable' | 'compact';
+export type DataTableSortDirection = 'asc' | 'desc';
+
+export interface DataTableSortState {
+  columnId: string;
+  direction: DataTableSortDirection;
+}
+
+export interface DataTableCellContext<TRow extends object> {
+  row: TRow;
+  rowIndex: number;
+  column: DataTableColumn<TRow>;
+  value: unknown;
+}
+
+export interface DataTableColumn<TRow extends object> {
+  id: string;
+  header: React.ReactNode;
+  accessor?: keyof TRow;
+  align?: DataTableColumnAlign;
+  width?: number;
+  minWidth?: number;
+  sortable?: boolean;
+  renderCell?: (context: DataTableCellContext<TRow>) => React.ReactNode;
+}
+
+export interface DataTableRowAction<TRow extends object> {
+  id: string;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  icon?: ButtonIconSpec;
+  intent?: MenuActionIntent;
+  disabled?: boolean;
+  onPress?: (row: TRow) => void;
+}
+
+export interface DataTableProps<TRow extends object> extends ZoraBaseProps {
+  columns: readonly DataTableColumn<TRow>[];
+  rows: readonly TRow[];
+  rowId: (row: TRow, index: number) => string;
+  rowActions?: (row: TRow, index: number) => readonly DataTableRowAction<TRow>[];
+  sort?: DataTableSortState;
+  onSortChange?: (sort: DataTableSortState) => void;
+  loading?: boolean;
+  loadingRows?: number;
+  emptyTitle?: React.ReactNode;
+  emptyDescription?: React.ReactNode;
+  density?: DataTableDensity;
+  testID?: string;
+}

--- a/src/components/data-table/types.ts
+++ b/src/components/data-table/types.ts
@@ -1,8 +1,8 @@
 import type { ButtonIconSpec } from '@ankhorage/surface';
 import type React from 'react';
 
-import type { MenuActionIntent } from '../menu';
 import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+import type { MenuActionIntent } from '../menu';
 
 export type DataTableColumnAlign = 'start' | 'center' | 'end';
 export type DataTableDensity = 'comfortable' | 'compact';

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,17 @@ export type { ChipProps } from './components/chip';
 export { Chip } from './components/chip';
 export type { ChipGroupItem, ChipGroupProps } from './components/chip-group';
 export { ChipGroup } from './components/chip-group';
+export type {
+  DataTableCellContext,
+  DataTableColumn,
+  DataTableColumnAlign,
+  DataTableDensity,
+  DataTableProps,
+  DataTableRowAction,
+  DataTableSortDirection,
+  DataTableSortState,
+} from './components/data-table';
+export { DataTable } from './components/data-table';
 export type { DrawerProps } from './components/drawer';
 export { Drawer } from './components/drawer';
 export type {

--- a/src/metadata/componentMeta.ts
+++ b/src/metadata/componentMeta.ts
@@ -9,6 +9,7 @@ import { cardMeta } from '../components/card/meta';
 import { checkboxGroupMeta, checkboxMeta } from '../components/checkbox/meta';
 import { chipMeta } from '../components/chip/meta';
 import { chipGroupMeta } from '../components/chip-group/meta';
+import { dataTableMeta } from '../components/data-table/meta';
 import { drawerMeta } from '../components/drawer/meta';
 import { formActionsMeta, formErrorMeta, formFieldMeta, formMeta } from '../components/form/meta';
 import { headingMeta } from '../components/heading/meta';
@@ -94,6 +95,7 @@ export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   CheckboxGroup: checkboxGroupMeta,
   Chip: chipMeta,
   ChipGroup: chipGroupMeta,
+  DataTable: dataTableMeta,
   Drawer: drawerMeta,
   DropdownMenu: dropdownMenuMeta,
   Form: formMeta,


### PR DESCRIPTION
## Summary

- add a generic `DataTable` component for typed app-facing tabular data
- support typed columns and rows with `accessor` and `renderCell`
- add controlled sort-state presentation with `sort` / `onSortChange`
- support row actions through the existing ZORA `DropdownMenu` / `MenuAction` API
- add loading state via `SkeletonList`
- add empty state via `EmptyState`
- add responsive rendering with a table-like layout on wider screens and card fallback on narrow screens
- export `DataTable` and public data table types from the root barrel
- register `DataTable` in `ZORA_COMPONENT_META` as a code-facing, non-manifest component
- add a patch changeset

Closes #210.

## Boundary

This stays ZORA-first. No Surface `DataTable` or low-level `Table` primitive is introduced.

Surface remains responsible for foundation primitives. ZORA owns the app-facing behavior: columns, row rendering, sort state, row actions, empty/loading states, and mobile fallback.

## Notes

V1 intentionally avoids virtualization, column resizing, column pinning, inline editing, grouped rows, pagination controllers, nested rows, and spreadsheet/data-grid behavior.

## Verification

Not run locally in this environment because the connected GitHub API path cannot execute repo commands. Please run before merge:

```bash
bun install
bun run knip
bun run lint
bun run build
bun run test
```