### PR TITLE
feat: add Pagination component

### DIFF
--- a/.changeset/pagination.md
+++ b/.changeset/pagination.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Add a controlled Pagination component for paged app data screens.

--- a/src/components/pagination/Pagination.tsx
+++ b/src/components/pagination/Pagination.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+
+import { Stack } from '../../foundation';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import { Button } from '../button';
+import { Text } from '../text';
+import type { PaginationProps } from './types';
+
+type PaginationItem = number | 'ellipsis';
+
+function clampInteger(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
+function createRange(start: number, end: number): number[] {
+  if (end < start) {
+    return [];
+  }
+
+  return Array.from({ length: end - start + 1 }, (_, index) => start + index);
+}
+
+function normalizeCount(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.max(0, Math.trunc(value));
+}
+
+function createPaginationItems({
+  page,
+  pageCount,
+  siblingCount,
+  boundaryCount,
+  compact,
+}: {
+  page: number;
+  pageCount: number;
+  siblingCount: number;
+  boundaryCount: number;
+  compact: boolean;
+}): readonly PaginationItem[] {
+  if (pageCount <= 0) {
+    return [];
+  }
+
+  if (compact) {
+    return [page];
+  }
+
+  const boundaries = createRange(1, Math.min(boundaryCount, pageCount));
+  const trailingBoundaries = createRange(Math.max(pageCount - boundaryCount + 1, 1), pageCount);
+  const siblings = createRange(
+    Math.max(page - siblingCount, 1),
+    Math.min(page + siblingCount, pageCount),
+  );
+  const pages = [...new Set([...boundaries, ...siblings, ...trailingBoundaries])].sort(
+    (left, right) => left - right,
+  );
+  const items: PaginationItem[] = [];
+
+  pages.forEach((nextPage, index) => {
+    const previousPage = pages[index - 1];
+    if (previousPage !== undefined && nextPage - previousPage > 1) {
+      items.push('ellipsis');
+    }
+
+    items.push(nextPage);
+  });
+
+  return items;
+}
+
+function PaginationInner({
+  themeId: _themeId,
+  mode: _mode,
+  page,
+  pageCount,
+  onPageChange,
+  disabled = false,
+  siblingCount = 1,
+  boundaryCount = 1,
+  showFirstLast = false,
+  previousLabel = 'Previous',
+  nextLabel = 'Next',
+  firstLabel = 'First',
+  lastLabel = 'Last',
+  compact = false,
+  testID,
+}: PaginationProps) {
+  const normalizedPageCount = Math.max(0, Math.trunc(Number.isFinite(pageCount) ? pageCount : 0));
+  const currentPage = clampInteger(page, 1, Math.max(normalizedPageCount, 1));
+  const safeSiblingCount = normalizeCount(siblingCount, 1);
+  const safeBoundaryCount = normalizeCount(boundaryCount, 1);
+  const items = createPaginationItems({
+    boundaryCount: safeBoundaryCount,
+    compact,
+    page: currentPage,
+    pageCount: normalizedPageCount,
+    siblingCount: safeSiblingCount,
+  });
+  const canGoPrevious = currentPage > 1;
+  const canGoNext = currentPage < normalizedPageCount;
+  const navigationDisabled = disabled || normalizedPageCount <= 1;
+
+  const changePage = (nextPage: number) => {
+    const clampedPage = clampInteger(nextPage, 1, Math.max(normalizedPageCount, 1));
+    if (disabled || clampedPage === currentPage) {
+      return;
+    }
+
+    onPageChange?.(clampedPage);
+  };
+
+  return (
+    <Stack align="center" direction="row" gap="xs" testID={testID}>
+      {showFirstLast ? (
+        <Button
+          disabled={navigationDisabled || currentPage === 1}
+          onPress={() => changePage(1)}
+          size="s"
+          testID={testID ? `${testID}-first` : undefined}
+          variant="ghost"
+        >
+          {firstLabel}
+        </Button>
+      ) : null}
+
+      <Button
+        disabled={navigationDisabled || !canGoPrevious}
+        onPress={() => changePage(currentPage - 1)}
+        size="s"
+        testID={testID ? `${testID}-previous` : undefined}
+        variant="ghost"
+      >
+        {previousLabel}
+      </Button>
+
+      {items.map((item, index) =>
+        item === 'ellipsis' ? (
+          <Text key={`ellipsis-${index}`} emphasis="muted" variant="bodySmall">
+            …
+          </Text>
+        ) : (
+          <Button
+            color={item === currentPage ? 'primary' : 'neutral'}
+            disabled={disabled}
+            key={item}
+            onPress={() => changePage(item)}
+            size="s"
+            testID={testID ? `${testID}-page-${item}` : undefined}
+            variant={item === currentPage ? 'solid' : 'ghost'}
+          >
+            {item}
+          </Button>
+        ),
+      )}
+
+      <Button
+        disabled={navigationDisabled || !canGoNext}
+        onPress={() => changePage(currentPage + 1)}
+        size="s"
+        testID={testID ? `${testID}-next` : undefined}
+        variant="ghost"
+      >
+        {nextLabel}
+      </Button>
+
+      {showFirstLast ? (
+        <Button
+          disabled={navigationDisabled || currentPage === normalizedPageCount}
+          onPress={() => changePage(normalizedPageCount)}
+          size="s"
+          testID={testID ? `${testID}-last` : undefined}
+          variant="ghost"
+        >
+          {lastLabel}
+        </Button>
+      ) : null}
+    </Stack>
+  );
+}
+
+export const Pagination = withZoraThemeScope(PaginationInner);

--- a/src/components/pagination/index.ts
+++ b/src/components/pagination/index.ts
@@ -1,0 +1,2 @@
+export { Pagination } from './Pagination';
+export type { PaginationProps } from './types';

--- a/src/components/pagination/meta.ts
+++ b/src/components/pagination/meta.ts
@@ -1,0 +1,10 @@
+import type { ZoraComponentMeta } from '../../metadata';
+
+export const paginationMeta = {
+  name: 'Pagination',
+  category: 'component',
+  directManifestNode: false,
+  allowedChildren: [],
+  note: 'Code-facing controlled pagination component; not represented as a manifest node in v1.',
+  props: {},
+} as const satisfies ZoraComponentMeta;

--- a/src/components/pagination/types.ts
+++ b/src/components/pagination/types.ts
@@ -1,0 +1,19 @@
+import type React from 'react';
+
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export interface PaginationProps extends ZoraBaseProps {
+  page: number;
+  pageCount: number;
+  onPageChange?: (page: number) => void;
+  disabled?: boolean;
+  siblingCount?: number;
+  boundaryCount?: number;
+  showFirstLast?: boolean;
+  previousLabel?: React.ReactNode;
+  nextLabel?: React.ReactNode;
+  firstLabel?: React.ReactNode;
+  lastLabel?: React.ReactNode;
+  compact?: boolean;
+  testID?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,8 @@ export type {
 export { NavigationItem } from './components/navigation-item';
 export type { NavigationListProps, ZoraNavigationRouteMap } from './components/navigation-list';
 export { NavigationList } from './components/navigation-list';
+export type { PaginationProps } from './components/pagination';
+export { Pagination } from './components/pagination';
 export type { ProgressProps } from './components/progress';
 export { Progress } from './components/progress';
 export type { RadioGroupOption, RadioGroupProps, RadioProps } from './components/radio';

--- a/src/metadata/componentMeta.ts
+++ b/src/metadata/componentMeta.ts
@@ -24,6 +24,7 @@ import { metricCardMeta } from '../components/metric-card/meta';
 import { modalMeta } from '../components/modal/meta';
 import { navigationItemMeta } from '../components/navigation-item/meta';
 import { navigationListMeta } from '../components/navigation-list/meta';
+import { paginationMeta } from '../components/pagination/meta';
 import { progressMeta } from '../components/progress/meta';
 import { radioGroupMeta, radioMeta } from '../components/radio/meta';
 import { ratingMeta } from '../components/rating/meta';
@@ -116,6 +117,7 @@ export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   Modal: modalMeta,
   NavigationItem: navigationItemMeta,
   NavigationList: navigationListMeta,
+  Pagination: paginationMeta,
   Progress: progressMeta,
   Radio: radioMeta,
   RadioGroup: radioGroupMeta,


### PR DESCRIPTION
## Summary

- add a controlled `Pagination` component for paged app data screens
- support 1-based `page` / `pageCount` state
- support `onPageChange` with clamped page targets
- render previous / next controls
- optionally render first / last controls
- render numeric page windows with ellipses
- support `siblingCount`, `boundaryCount`, `compact`, labels, disabled state, and `testID`
- export `Pagination` and `PaginationProps` from the root barrel
- register `Pagination` in `ZORA_COMPONENT_META` as a code-facing, non-manifest component
- add a patch changeset

Closes #217.

## Boundary

This stays ZORA-first. No Surface `Pagination`, `Pager`, or `PageControl` primitive is introduced.

Pagination remains independent from `DataTable`: screen/data fetching state stays owned by the consumer.

## Out of scope

- data fetching
- server-side pagination controller
- cursor abstraction
- infinite scroll
- page-size selector
- URL/router integration
- DataTable-owned pagination state
- virtualization

## Verification

Not run locally in this environment because the connected GitHub API path cannot execute repo commands. Please run before merge:

```bash
bun install
bun run knip
bun run lint
bun run build
bun run test
```