### PR TITLE
feat: add Breadcrumbs component

### DIFF
--- a/.changeset/breadcrumbs.md
+++ b/.changeset/breadcrumbs.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Add a Breadcrumbs component for app-facing route hierarchy and navigation context.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ graph TD
   package__ankhorage_zora -.-> module_src_components_badge_types_ts
   module_src_components_badge_types_ts --> module_src_internal_recipes_ts
   module_src_components_badge_types_ts --> module_src_theme_ZoraBaseProps_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx["src/components/breadcrumbs/Breadcrumbs.tsx"]
+  package__ankhorage_zora -.-> module_src_components_breadcrumbs_Breadcrumbs_tsx
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_breadcrumbs_types_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_button_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_icon_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_text_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_foundation_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_internal_recipes_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_theme_useZoraTheme_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_theme_withZoraThemeScope_tsx
+  module_src_components_breadcrumbs_index_ts["src/components/breadcrumbs/index.ts"]
+  package__ankhorage_zora -.-> module_src_components_breadcrumbs_index_ts
+  module_src_components_breadcrumbs_meta_ts["src/components/breadcrumbs/meta.ts"]
+  package__ankhorage_zora -.-> module_src_components_breadcrumbs_meta_ts
+  module_src_components_breadcrumbs_meta_ts --> module_src_metadata_index_ts
+  module_src_components_breadcrumbs_types_ts["src/components/breadcrumbs/types.ts"]
+  package__ankhorage_zora -.-> module_src_components_breadcrumbs_types_ts
+  module_src_components_breadcrumbs_types_ts --> module_src_theme_ZoraBaseProps_ts
   module_src_components_button_group_ButtonGroup_tsx["src/components/button-group/ButtonGroup.tsx"]
   package__ankhorage_zora -.-> module_src_components_button_group_ButtonGroup_tsx
   module_src_components_button_group_ButtonGroup_tsx --> module_src_components_button_group_types_ts
@@ -884,6 +902,7 @@ graph TD
   module_src_metadata_componentMeta_ts --> module_src_components_avatar_group_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_avatar_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_badge_meta_ts
+  module_src_metadata_componentMeta_ts --> module_src_components_breadcrumbs_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_button_group_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_button_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_card_meta_ts

--- a/paradox/components.md
+++ b/paradox/components.md
@@ -186,6 +186,23 @@ Export paths: `src/index.ts`
 | width              | `Responsive<string \| number> \| undefined`                                                                                      | no       | —       |             |
 | zIndex             | `Responsive<number> \| undefined`                                                                                                | no       | —       |             |
 
+## Breadcrumbs
+
+Source: `src/components/breadcrumbs/Breadcrumbs.tsx:143:14`
+
+Export paths: `src/index.ts`
+
+| Prop      | Type                         | Required | Default | Description |
+| --------- | ---------------------------- | -------- | ------- | ----------- |
+| compact   | `boolean \| undefined`       | no       | —       |             |
+| disabled  | `boolean \| undefined`       | no       | —       |             |
+| items     | `readonly BreadcrumbItem[]`  | yes      | —       |             |
+| maxItems  | `number \| undefined`        | no       | —       |             |
+| mode      | `ZoraThemeMode \| undefined` | no       | —       |             |
+| separator | `React.ReactNode`            | no       | —       |             |
+| testID    | `string \| undefined`        | no       | —       |             |
+| themeId   | `string \| undefined`        | no       | —       |             |
+
 ## Button
 
 Source: `src/components/button/Button.tsx:23:14`

--- a/paradox/diagrams/architecture-overview.mmd
+++ b/paradox/diagrams/architecture-overview.mmd
@@ -91,6 +91,24 @@ graph TD
   package__ankhorage_zora -.-> module_src_components_badge_types_ts
   module_src_components_badge_types_ts --> module_src_internal_recipes_ts
   module_src_components_badge_types_ts --> module_src_theme_ZoraBaseProps_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx["src/components/breadcrumbs/Breadcrumbs.tsx"]
+  package__ankhorage_zora -.-> module_src_components_breadcrumbs_Breadcrumbs_tsx
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_breadcrumbs_types_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_button_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_icon_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_text_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_foundation_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_internal_recipes_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_theme_useZoraTheme_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_theme_withZoraThemeScope_tsx
+  module_src_components_breadcrumbs_index_ts["src/components/breadcrumbs/index.ts"]
+  package__ankhorage_zora -.-> module_src_components_breadcrumbs_index_ts
+  module_src_components_breadcrumbs_meta_ts["src/components/breadcrumbs/meta.ts"]
+  package__ankhorage_zora -.-> module_src_components_breadcrumbs_meta_ts
+  module_src_components_breadcrumbs_meta_ts --> module_src_metadata_index_ts
+  module_src_components_breadcrumbs_types_ts["src/components/breadcrumbs/types.ts"]
+  package__ankhorage_zora -.-> module_src_components_breadcrumbs_types_ts
+  module_src_components_breadcrumbs_types_ts --> module_src_theme_ZoraBaseProps_ts
   module_src_components_button_group_ButtonGroup_tsx["src/components/button-group/ButtonGroup.tsx"]
   package__ankhorage_zora -.-> module_src_components_button_group_ButtonGroup_tsx
   module_src_components_button_group_ButtonGroup_tsx --> module_src_components_button_group_types_ts
@@ -851,6 +869,7 @@ graph TD
   module_src_metadata_componentMeta_ts --> module_src_components_avatar_group_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_avatar_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_badge_meta_ts
+  module_src_metadata_componentMeta_ts --> module_src_components_breadcrumbs_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_button_group_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_button_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_card_meta_ts

--- a/paradox/diagrams/export-graph.mmd
+++ b/paradox/diagrams/export-graph.mmd
@@ -21,6 +21,10 @@ graph LR
   module_src_components_badge_index_ts["src/components/badge/index.ts"]
   module_src_components_badge_meta_ts["src/components/badge/meta.ts"]
   module_src_components_badge_types_ts["src/components/badge/types.ts"]
+  module_src_components_breadcrumbs_Breadcrumbs_tsx["src/components/breadcrumbs/Breadcrumbs.tsx"]
+  module_src_components_breadcrumbs_index_ts["src/components/breadcrumbs/index.ts"]
+  module_src_components_breadcrumbs_meta_ts["src/components/breadcrumbs/meta.ts"]
+  module_src_components_breadcrumbs_types_ts["src/components/breadcrumbs/types.ts"]
   module_src_components_button_group_ButtonGroup_tsx["src/components/button-group/ButtonGroup.tsx"]
   module_src_components_button_group_index_ts["src/components/button-group/index.ts"]
   module_src_components_button_group_meta_ts["src/components/button-group/meta.ts"]
@@ -414,6 +418,14 @@ graph LR
   export_BoxProps["BoxProps"]
   module_src_foundation_Box_tsx --> export_BoxProps
   export_BoxProps -.-> export_ZoraThemeMode
+  export_BreadcrumbItem["BreadcrumbItem"]
+  module_src_components_breadcrumbs_types_ts --> export_BreadcrumbItem
+  export_Breadcrumbs["Breadcrumbs"]
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> export_Breadcrumbs
+  export_BreadcrumbsProps["BreadcrumbsProps"]
+  module_src_components_breadcrumbs_types_ts --> export_BreadcrumbsProps
+  export_BreadcrumbsProps -.-> export_BreadcrumbItem
+  export_BreadcrumbsProps -.-> export_ZoraThemeMode
   export_Button["Button"]
   module_src_components_button_Button_tsx --> export_Button
   export_ButtonGroup["ButtonGroup"]

--- a/paradox/diagrams/module-relationships.mmd
+++ b/paradox/diagrams/module-relationships.mmd
@@ -21,6 +21,10 @@ graph LR
   module_src_components_badge_index_ts["src/components/badge/index.ts"]
   module_src_components_badge_meta_ts["src/components/badge/meta.ts"]
   module_src_components_badge_types_ts["src/components/badge/types.ts"]
+  module_src_components_breadcrumbs_Breadcrumbs_tsx["src/components/breadcrumbs/Breadcrumbs.tsx"]
+  module_src_components_breadcrumbs_index_ts["src/components/breadcrumbs/index.ts"]
+  module_src_components_breadcrumbs_meta_ts["src/components/breadcrumbs/meta.ts"]
+  module_src_components_breadcrumbs_types_ts["src/components/breadcrumbs/types.ts"]
   module_src_components_button_group_ButtonGroup_tsx["src/components/button-group/ButtonGroup.tsx"]
   module_src_components_button_group_index_ts["src/components/button-group/index.ts"]
   module_src_components_button_group_meta_ts["src/components/button-group/meta.ts"]
@@ -397,6 +401,16 @@ graph LR
   module_src_components_badge_meta_ts --> module_src_metadata_index_ts
   module_src_components_badge_types_ts --> module_src_internal_recipes_ts
   module_src_components_badge_types_ts --> module_src_theme_ZoraBaseProps_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_breadcrumbs_types_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_button_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_icon_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_components_text_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_foundation_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_internal_recipes_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_theme_useZoraTheme_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --> module_src_theme_withZoraThemeScope_tsx
+  module_src_components_breadcrumbs_meta_ts --> module_src_metadata_index_ts
+  module_src_components_breadcrumbs_types_ts --> module_src_theme_ZoraBaseProps_ts
   module_src_components_button_group_ButtonGroup_tsx --> module_src_components_button_group_types_ts
   module_src_components_button_group_ButtonGroup_tsx --> module_src_foundation_index_ts
   module_src_components_button_group_ButtonGroup_tsx --> module_src_theme_withZoraThemeScope_tsx
@@ -768,6 +782,7 @@ graph LR
   module_src_metadata_componentMeta_ts --> module_src_components_avatar_group_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_avatar_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_badge_meta_ts
+  module_src_metadata_componentMeta_ts --> module_src_components_breadcrumbs_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_button_group_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_button_meta_ts
   module_src_metadata_componentMeta_ts --> module_src_components_card_meta_ts

--- a/paradox/exports.json
+++ b/paradox/exports.json
@@ -1349,6 +1349,153 @@
     "structuredRows": []
   },
   {
+    "name": "BreadcrumbItem",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/components/breadcrumbs/types.ts",
+    "sourceLocation": {
+      "filePath": "src/components/breadcrumbs/types.ts",
+      "line": 6,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [
+      {
+        "name": "disabled",
+        "kind": "property",
+        "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "icon",
+        "kind": "property",
+        "type": "ButtonIconSpec | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "id",
+        "kind": "property",
+        "type": "string",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "label",
+        "kind": "property",
+        "type": "React.ReactNode",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "onPress",
+        "kind": "property",
+        "type": "(() => void) | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
+    "name": "Breadcrumbs",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "value",
+    "modulePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+    "sourceLocation": {
+      "filePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+      "line": 143,
+      "column": 14
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": [],
+    "signatures": [],
+    "members": [],
+    "structuredRows": []
+  },
+  {
+    "name": "BreadcrumbsProps",
+    "description": null,
+    "isReadme": false,
+    "examples": [],
+    "kind": "type",
+    "modulePath": "src/components/breadcrumbs/types.ts",
+    "sourceLocation": {
+      "filePath": "src/components/breadcrumbs/types.ts",
+      "line": 14,
+      "column": 1
+    },
+    "exportPaths": ["src/index.ts"],
+    "relatedSymbols": ["BreadcrumbItem", "ZoraThemeMode"],
+    "signatures": [],
+    "members": [
+      {
+        "name": "compact",
+        "kind": "property",
+        "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "disabled",
+        "kind": "property",
+        "type": "boolean | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "items",
+        "kind": "property",
+        "type": "readonly BreadcrumbItem[]",
+        "required": true,
+        "description": null
+      },
+      {
+        "name": "maxItems",
+        "kind": "property",
+        "type": "number | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "mode",
+        "kind": "property",
+        "type": "ZoraThemeMode | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "separator",
+        "kind": "property",
+        "type": "React.ReactNode",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "testID",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      },
+      {
+        "name": "themeId",
+        "kind": "property",
+        "type": "string | undefined",
+        "required": false,
+        "description": null
+      }
+    ],
+    "structuredRows": []
+  },
+  {
     "name": "Button",
     "description": null,
     "isReadme": false,
@@ -18168,7 +18315,7 @@
     "modulePath": "src/metadata/componentMeta.ts",
     "sourceLocation": {
       "filePath": "src/metadata/componentMeta.ts",
-      "line": 86,
+      "line": 87,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],

--- a/paradox/exports.md
+++ b/paradox/exports.md
@@ -325,6 +325,47 @@ Source: `src/foundation/Box.tsx:7:1`
 | width              | property | `Responsive<string \| number> \| undefined`                                                                                      | no       |             |
 | zIndex             | property | `Responsive<number> \| undefined`                                                                                                | no       |             |
 
+## BreadcrumbItem
+
+Kind: `type`
+Module: `src/components/breadcrumbs/types.ts`
+Source: `src/components/breadcrumbs/types.ts:6:1`
+
+### Members
+
+| Name     | Kind     | Type                          | Required | Description |
+| -------- | -------- | ----------------------------- | -------- | ----------- |
+| disabled | property | `boolean \| undefined`        | no       |             |
+| icon     | property | `ButtonIconSpec \| undefined` | no       |             |
+| id       | property | `string`                      | yes      |             |
+| label    | property | `React.ReactNode`             | yes      |             |
+| onPress  | property | `(() => void) \| undefined`   | no       |             |
+
+## Breadcrumbs
+
+Kind: `value`
+Module: `src/components/breadcrumbs/Breadcrumbs.tsx`
+Source: `src/components/breadcrumbs/Breadcrumbs.tsx:143:14`
+
+## BreadcrumbsProps
+
+Kind: `type`
+Module: `src/components/breadcrumbs/types.ts`
+Source: `src/components/breadcrumbs/types.ts:14:1`
+
+### Members
+
+| Name      | Kind     | Type                         | Required | Description |
+| --------- | -------- | ---------------------------- | -------- | ----------- |
+| compact   | property | `boolean \| undefined`       | no       |             |
+| disabled  | property | `boolean \| undefined`       | no       |             |
+| items     | property | `readonly BreadcrumbItem[]`  | yes      |             |
+| maxItems  | property | `number \| undefined`        | no       |             |
+| mode      | property | `ZoraThemeMode \| undefined` | no       |             |
+| separator | property | `React.ReactNode`            | no       |             |
+| testID    | property | `string \| undefined`        | no       |             |
+| themeId   | property | `string \| undefined`        | no       |             |
+
 ## Button
 
 Kind: `value`
@@ -4351,7 +4392,7 @@ Source: `src/internal/colorModel.ts:28:14`
 
 Kind: `value`
 Module: `src/metadata/componentMeta.ts`
-Source: `src/metadata/componentMeta.ts:86:14`
+Source: `src/metadata/componentMeta.ts:87:14`
 
 ## ZORA_EMPHASES
 

--- a/paradox/index.html
+++ b/paradox/index.html
@@ -267,6 +267,16 @@
               <button
                 class="nav-button"
                 type="button"
+                data-target="src/components/breadcrumbs/Breadcrumbs.tsx"
+              >
+                src/components/breadcrumbs/Breadcrumbs.tsx
+                <small>5 functions</small>
+              </button>
+            </li>
+            <li>
+              <button
+                class="nav-button"
+                type="button"
                 data-target="src/components/button-group/ButtonGroup.tsx"
               >
                 src/components/button-group/ButtonGroup.tsx
@@ -1321,9 +1331,9 @@
           <section class="panel">
             <h2>Package overview</h2>
             <div class="summary">
-              <div><strong>346</strong><span class="muted">public exports</span></div>
-              <div><strong>104</strong><span class="muted">components</span></div>
-              <div><strong>353</strong><span class="muted">modules</span></div>
+              <div><strong>349</strong><span class="muted">public exports</span></div>
+              <div><strong>105</strong><span class="muted">components</span></div>
+              <div><strong>357</strong><span class="muted">modules</span></div>
               <div><strong>1</strong><span class="muted">entrypoints</span></div>
             </div>
             <h3>Entrypoints</h3>
@@ -1599,6 +1609,54 @@
                 <code>src/theme/ZoraBaseProps.ts</code>
               </p>
               <p><strong>Exports:</strong> <code>BadgeProps</code></p>
+            </article>
+            <article
+              class="item"
+              data-search="src/components/breadcrumbs/Breadcrumbs.tsx src/components/breadcrumbs/types.ts src/components/button/index.ts src/components/icon/index.ts src/components/text/index.ts src/foundation/index.ts src/internal/recipes.ts src/theme/useZoraTheme.ts src/theme/withZoraThemeScope.tsx Breadcrumbs"
+            >
+              <h3>src/components/breadcrumbs/Breadcrumbs.tsx</h3>
+              <p class="muted">Referenced module</p>
+              <p>
+                <strong>Dependencies:</strong> <code>src/components/breadcrumbs/types.ts</code>,
+                <code>src/components/button/index.ts</code>,
+                <code>src/components/icon/index.ts</code>,
+                <code>src/components/text/index.ts</code>, <code>src/foundation/index.ts</code>,
+                <code>src/internal/recipes.ts</code>, <code>src/theme/useZoraTheme.ts</code>,
+                <code>src/theme/withZoraThemeScope.tsx</code>
+              </p>
+              <p><strong>Exports:</strong> <code>Breadcrumbs</code></p>
+            </article>
+            <article
+              class="item"
+              data-search="src/components/breadcrumbs/index.ts BreadcrumbItem Breadcrumbs BreadcrumbsProps"
+            >
+              <h3>src/components/breadcrumbs/index.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p><strong>Dependencies:</strong> <span class="empty">None</span></p>
+              <p>
+                <strong>Exports:</strong> <code>BreadcrumbItem</code>, <code>Breadcrumbs</code>,
+                <code>BreadcrumbsProps</code>
+              </p>
+            </article>
+            <article
+              class="item"
+              data-search="src/components/breadcrumbs/meta.ts src/metadata/index.ts breadcrumbsMeta"
+            >
+              <h3>src/components/breadcrumbs/meta.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p><strong>Dependencies:</strong> <code>src/metadata/index.ts</code></p>
+              <p><strong>Exports:</strong> <code>breadcrumbsMeta</code></p>
+            </article>
+            <article
+              class="item"
+              data-search="src/components/breadcrumbs/types.ts src/theme/ZoraBaseProps.ts BreadcrumbItem BreadcrumbsProps"
+            >
+              <h3>src/components/breadcrumbs/types.ts</h3>
+              <p class="muted">Referenced module</p>
+              <p><strong>Dependencies:</strong> <code>src/theme/ZoraBaseProps.ts</code></p>
+              <p>
+                <strong>Exports:</strong> <code>BreadcrumbItem</code>, <code>BreadcrumbsProps</code>
+              </p>
             </article>
             <article
               class="item"
@@ -3585,7 +3643,7 @@
             </article>
             <article
               class="item"
-              data-search="src/index.ts ActionSheet ActionSheetItem ActionSheetItemProps ActionSheetProps AppBar AppBarMode AppBarOverflowAction AppBarProps AppShell AppShellProps AuthFormBaseProps AuthIdentifierKind Avatar AvatarGroup AvatarGroupItem AvatarGroupProps AvatarProps AvatarShape AvatarSize Badge BadgeProps Box BoxProps Button ButtonGroup ButtonGroupAlign ButtonGroupOrientation ButtonGroupProps ButtonProps Card CardProps Center CenterProps ChatListAvatar ChatListItem ChatListItemProps Checkbox CheckboxGroup CheckboxGroupOption CheckboxGroupProps CheckboxProps Chip ChipGroup ChipGroupItem ChipGroupProps ChipProps CollectionEditor CollectionEditorProps CollectionEditorRenderItemProps ConfirmDialog ConfirmDialogProps Container ContainerProps createZoraThemeConfig DataTable DataTableCellContext DataTableColumn DataTableColumnAlign DataTableDensity DataTableProps DataTableRowAction DataTableSortDirection DataTableSortState DatePicker DatePickerProps DatePickerValue DisclosureSection DisclosureSectionProps Divider DividerProps Drawer DrawerProps DropdownMenu DropdownMenuProps EmptyState EmptyStateAction EmptyStateProps FilterBar FilterBarProps ForgotPasswordForm ForgotPasswordFormProps ForgotPasswordFormValues Form FormActions FormActionsProps FormError FormErrorProps FormErrors FormField FormFieldConfig FormFieldControlProps FormFieldInputType FormFieldProps FormFieldValue FormProps FormValidationErrors FormValidationResult FormValues Grid GridProps hasRequiredRule Heading HeadingAlign HeadingColor HeadingEmphasis HeadingLevel HeadingProps HeadingSize HeadingWeight Hero HeroAction HeroAlign HeroLayout HeroProps HeroTone Icon IconButton IconButtonProps IconProps Image ImageFit ImagePreview ImagePreviewProps ImageProps ImageUploadField ImageUploadFieldProps ImageUploadProgressContext Inline InlineProps Input InputProps InputTrailingAction InspectorField InspectorFieldProps List ListChildrenProps ListItemsProps ListProps ListRow ListRowProps ListRowVariant ListSection MediaCard MediaCardImageProps MediaCardProps Menu MenuAction MenuActionIntent MenuProps MessageBubble MessageBubbleAuthor MessageBubbleAvatar MessageBubbleDirection MessageBubbleProps MessageBubbleStatus MetricCard MetricCardProps Modal ModalProps NavigationItem NavigationItemProps NavigationList NavigationListProps Notice NoticeProps OtpForm OtpFormProps OtpFormValues Pagination PaginationProps PaletteItem PaletteItemProps Panel PanelProps PostAction PostAuthor PostAuthorAvatar PostCard PostCardMedia PostCardProps Progress ProgressProps Radio RadioGroup RadioGroupOption RadioGroupProps RadioProps Rating RatingProps resolveAvatarInitials ResponsivePanel ResponsivePanelDesktopMode ResponsivePanelMobileMode ResponsivePanelProps ResponsivePanelSide Screen ScreenProps ScreenSection ScreenSectionProps SearchBar SearchBarProps SectionHeader SectionHeaderProps Select SelectableItem SelectableItemProps SelectableItemState SelectionMode SelectionProvider SelectionProviderProps SelectionTrigger SelectOption SelectProps SettingsLayout SettingsLayoutProps SettingsRow SettingsRowProps Show ShowProps SidebarLayout SidebarLayoutProps SignInForm SignInFormProps SignInFormValues SignUpForm SignUpFormField SignUpFormProps SignUpFormValues Skeleton SkeletonCard SkeletonCardProps SkeletonDimension SkeletonList SkeletonListProps SkeletonListVariant SkeletonProps SkeletonRadius SkeletonText SkeletonTextProps Spacer SpacerProps Stack StackProps Surface SurfaceImageSource SurfaceProps SurfaceVariant SwitchField SwitchFieldProps TabItem Tabs TabsProps TabsVariant Text TextAlign Textarea TextareaProps TextColor TextEmphasis TextProps TextVariant TextWeight ThemeComposer ThemeComposerProps TileGrid TileGridProps Timeline TimelineItem TimelineProps TimePicker TimePickerProps TimePickerValue Toast ToastOptions ToastProps ToastProvider ToastProviderProps ToastStatus Toolbar ToolbarAction ToolbarActionProps ToolbarPosition ToolbarProps TopbarLayout TopbarLayoutProps TreeItem TreeItemNode TreeItemRenderProps TreeView TreeViewProps useFormController UseFormControllerOptions UseFormControllerResult useSelection UseSelectionResult useToast useZoraTheme validateField validateFields validateValue ValidationRule withZoraThemeScope ZORA_COLORS ZORA_COMPONENT_META ZORA_EMPHASES ZORA_PALETTE_COLORS ZORA_STATUS_COLORS ZoraBaseProps ZoraColor ZoraComponentBlueprint ZoraComponentCategory ZoraComponentEventMeta ZoraComponentEventPayloadFieldMeta ZoraComponentEventPayloadFieldType ZoraComponentEventPayloadKind ZoraComponentI18nMeta ZoraComponentMeta ZoraComponentMetaRegistry ZoraComponentPropArrayItemSchema ZoraComponentPropSchema ZoraComponentPropType ZoraComponentPropValue ZoraComponentSlotMeta ZoraComputedTheme ZoraComputedThemeMode zoraDefaultTheme ZoraDrawerContent ZoraDrawerContentProps ZoraEmphasis ZoraImageAsset ZoraImageMetadata ZoraNavigationRouteMap ZoraNavigationRouteMetadata ZoraNavigationRouteState ZoraPaletteColor ZoraPickedImage ZoraProvider ZoraProviderProps ZoraStatusColor ZoraTabBar ZoraTabBarProps ZoraTheme ZoraThemeId ZoraThemeMode ZoraThemeScope ZoraThemeScopeProps"
+              data-search="src/index.ts ActionSheet ActionSheetItem ActionSheetItemProps ActionSheetProps AppBar AppBarMode AppBarOverflowAction AppBarProps AppShell AppShellProps AuthFormBaseProps AuthIdentifierKind Avatar AvatarGroup AvatarGroupItem AvatarGroupProps AvatarProps AvatarShape AvatarSize Badge BadgeProps Box BoxProps BreadcrumbItem Breadcrumbs BreadcrumbsProps Button ButtonGroup ButtonGroupAlign ButtonGroupOrientation ButtonGroupProps ButtonProps Card CardProps Center CenterProps ChatListAvatar ChatListItem ChatListItemProps Checkbox CheckboxGroup CheckboxGroupOption CheckboxGroupProps CheckboxProps Chip ChipGroup ChipGroupItem ChipGroupProps ChipProps CollectionEditor CollectionEditorProps CollectionEditorRenderItemProps ConfirmDialog ConfirmDialogProps Container ContainerProps createZoraThemeConfig DataTable DataTableCellContext DataTableColumn DataTableColumnAlign DataTableDensity DataTableProps DataTableRowAction DataTableSortDirection DataTableSortState DatePicker DatePickerProps DatePickerValue DisclosureSection DisclosureSectionProps Divider DividerProps Drawer DrawerProps DropdownMenu DropdownMenuProps EmptyState EmptyStateAction EmptyStateProps FilterBar FilterBarProps ForgotPasswordForm ForgotPasswordFormProps ForgotPasswordFormValues Form FormActions FormActionsProps FormError FormErrorProps FormErrors FormField FormFieldConfig FormFieldControlProps FormFieldInputType FormFieldProps FormFieldValue FormProps FormValidationErrors FormValidationResult FormValues Grid GridProps hasRequiredRule Heading HeadingAlign HeadingColor HeadingEmphasis HeadingLevel HeadingProps HeadingSize HeadingWeight Hero HeroAction HeroAlign HeroLayout HeroProps HeroTone Icon IconButton IconButtonProps IconProps Image ImageFit ImagePreview ImagePreviewProps ImageProps ImageUploadField ImageUploadFieldProps ImageUploadProgressContext Inline InlineProps Input InputProps InputTrailingAction InspectorField InspectorFieldProps List ListChildrenProps ListItemsProps ListProps ListRow ListRowProps ListRowVariant ListSection MediaCard MediaCardImageProps MediaCardProps Menu MenuAction MenuActionIntent MenuProps MessageBubble MessageBubbleAuthor MessageBubbleAvatar MessageBubbleDirection MessageBubbleProps MessageBubbleStatus MetricCard MetricCardProps Modal ModalProps NavigationItem NavigationItemProps NavigationList NavigationListProps Notice NoticeProps OtpForm OtpFormProps OtpFormValues Pagination PaginationProps PaletteItem PaletteItemProps Panel PanelProps PostAction PostAuthor PostAuthorAvatar PostCard PostCardMedia PostCardProps Progress ProgressProps Radio RadioGroup RadioGroupOption RadioGroupProps RadioProps Rating RatingProps resolveAvatarInitials ResponsivePanel ResponsivePanelDesktopMode ResponsivePanelMobileMode ResponsivePanelProps ResponsivePanelSide Screen ScreenProps ScreenSection ScreenSectionProps SearchBar SearchBarProps SectionHeader SectionHeaderProps Select SelectableItem SelectableItemProps SelectableItemState SelectionMode SelectionProvider SelectionProviderProps SelectionTrigger SelectOption SelectProps SettingsLayout SettingsLayoutProps SettingsRow SettingsRowProps Show ShowProps SidebarLayout SidebarLayoutProps SignInForm SignInFormProps SignInFormValues SignUpForm SignUpFormField SignUpFormProps SignUpFormValues Skeleton SkeletonCard SkeletonCardProps SkeletonDimension SkeletonList SkeletonListProps SkeletonListVariant SkeletonProps SkeletonRadius SkeletonText SkeletonTextProps Spacer SpacerProps Stack StackProps Surface SurfaceImageSource SurfaceProps SurfaceVariant SwitchField SwitchFieldProps TabItem Tabs TabsProps TabsVariant Text TextAlign Textarea TextareaProps TextColor TextEmphasis TextProps TextVariant TextWeight ThemeComposer ThemeComposerProps TileGrid TileGridProps Timeline TimelineItem TimelineProps TimePicker TimePickerProps TimePickerValue Toast ToastOptions ToastProps ToastProvider ToastProviderProps ToastStatus Toolbar ToolbarAction ToolbarActionProps ToolbarPosition ToolbarProps TopbarLayout TopbarLayoutProps TreeItem TreeItemNode TreeItemRenderProps TreeView TreeViewProps useFormController UseFormControllerOptions UseFormControllerResult useSelection UseSelectionResult useToast useZoraTheme validateField validateFields validateValue ValidationRule withZoraThemeScope ZORA_COLORS ZORA_COMPONENT_META ZORA_EMPHASES ZORA_PALETTE_COLORS ZORA_STATUS_COLORS ZoraBaseProps ZoraColor ZoraComponentBlueprint ZoraComponentCategory ZoraComponentEventMeta ZoraComponentEventPayloadFieldMeta ZoraComponentEventPayloadFieldType ZoraComponentEventPayloadKind ZoraComponentI18nMeta ZoraComponentMeta ZoraComponentMetaRegistry ZoraComponentPropArrayItemSchema ZoraComponentPropSchema ZoraComponentPropType ZoraComponentPropValue ZoraComponentSlotMeta ZoraComputedTheme ZoraComputedThemeMode zoraDefaultTheme ZoraDrawerContent ZoraDrawerContentProps ZoraEmphasis ZoraImageAsset ZoraImageMetadata ZoraNavigationRouteMap ZoraNavigationRouteMetadata ZoraNavigationRouteState ZoraPaletteColor ZoraPickedImage ZoraProvider ZoraProviderProps ZoraStatusColor ZoraTabBar ZoraTabBarProps ZoraTheme ZoraThemeId ZoraThemeMode ZoraThemeScope ZoraThemeScopeProps"
             >
               <h3>src/index.ts</h3>
               <p class="muted">Configured entrypoint</p>
@@ -3599,7 +3657,8 @@
                 <code>Avatar</code>, <code>AvatarGroup</code>, <code>AvatarGroupItem</code>,
                 <code>AvatarGroupProps</code>, <code>AvatarProps</code>, <code>AvatarShape</code>,
                 <code>AvatarSize</code>, <code>Badge</code>, <code>BadgeProps</code>,
-                <code>Box</code>, <code>BoxProps</code>, <code>Button</code>,
+                <code>Box</code>, <code>BoxProps</code>, <code>BreadcrumbItem</code>,
+                <code>Breadcrumbs</code>, <code>BreadcrumbsProps</code>, <code>Button</code>,
                 <code>ButtonGroup</code>, <code>ButtonGroupAlign</code>,
                 <code>ButtonGroupOrientation</code>, <code>ButtonGroupProps</code>,
                 <code>ButtonProps</code>, <code>Card</code>, <code>CardProps</code>,
@@ -4058,7 +4117,7 @@
             </article>
             <article
               class="item"
-              data-search="src/metadata/componentMeta.ts src/components/action-sheet/meta.ts src/components/app-bar/meta.ts src/components/avatar-group/meta.ts src/components/avatar/meta.ts src/components/badge/meta.ts src/components/button-group/meta.ts src/components/button/meta.ts src/components/card/meta.ts src/components/checkbox/meta.ts src/components/chip-group/meta.ts src/components/chip/meta.ts src/components/data-table/meta.ts src/components/date-picker/meta.ts src/components/drawer/meta.ts src/components/form/meta.ts src/components/heading/meta.ts src/components/icon-button/meta.ts src/components/icon/meta.ts src/components/image/meta.ts src/components/input/meta.ts src/components/media-card/meta.ts src/components/menu/meta.ts src/components/metric-card/meta.ts src/components/modal/meta.ts src/components/navigation-item/meta.ts src/components/navigation-list/meta.ts src/components/pagination/meta.ts src/components/progress/meta.ts src/components/radio/meta.ts src/components/rating/meta.ts src/components/search-bar/meta.ts src/components/select/meta.ts src/components/skeleton/meta.ts src/components/tabs/meta.ts src/components/text/meta.ts src/components/textarea/meta.ts src/components/time-picker/meta.ts src/components/toast/meta.ts src/components/toolbar/meta.ts src/foundation/meta.ts src/layout/app-shell/meta.ts src/layout/screen-section/meta.ts src/layout/screen/meta.ts src/layout/settings-layout/meta.ts src/layout/sidebar-layout/meta.ts src/layout/topbar-layout/meta.ts src/metadata/types.ts src/patterns/auth/meta.ts src/patterns/chat-list-item/meta.ts src/patterns/collection-editor/meta.ts src/patterns/confirm-dialog/meta.ts src/patterns/disclosure-section/meta.ts src/patterns/empty-state/meta.ts src/patterns/filter-bar/meta.ts src/patterns/hero/meta.ts src/patterns/image-preview/meta.ts src/patterns/image-upload-field/meta.ts src/patterns/inspector-field/meta.ts src/patterns/list/meta.ts src/patterns/message-bubble/meta.ts src/patterns/notice/meta.ts src/patterns/panel/meta.ts src/patterns/post-card/meta.ts src/patterns/responsive-panel/meta.ts src/patterns/section-header/meta.ts src/patterns/selection/meta.ts src/patterns/settings-row/meta.ts src/patterns/switch-field/meta.ts src/patterns/theme-composer/meta.ts src/patterns/tile-grid/meta.ts src/patterns/timeline/meta.ts src/patterns/tree-view/meta.ts src/patterns/zora-drawer-content/meta.ts src/patterns/zora-tab-bar/meta.ts ZORA_COMPONENT_META"
+              data-search="src/metadata/componentMeta.ts src/components/action-sheet/meta.ts src/components/app-bar/meta.ts src/components/avatar-group/meta.ts src/components/avatar/meta.ts src/components/badge/meta.ts src/components/breadcrumbs/meta.ts src/components/button-group/meta.ts src/components/button/meta.ts src/components/card/meta.ts src/components/checkbox/meta.ts src/components/chip-group/meta.ts src/components/chip/meta.ts src/components/data-table/meta.ts src/components/date-picker/meta.ts src/components/drawer/meta.ts src/components/form/meta.ts src/components/heading/meta.ts src/components/icon-button/meta.ts src/components/icon/meta.ts src/components/image/meta.ts src/components/input/meta.ts src/components/media-card/meta.ts src/components/menu/meta.ts src/components/metric-card/meta.ts src/components/modal/meta.ts src/components/navigation-item/meta.ts src/components/navigation-list/meta.ts src/components/pagination/meta.ts src/components/progress/meta.ts src/components/radio/meta.ts src/components/rating/meta.ts src/components/search-bar/meta.ts src/components/select/meta.ts src/components/skeleton/meta.ts src/components/tabs/meta.ts src/components/text/meta.ts src/components/textarea/meta.ts src/components/time-picker/meta.ts src/components/toast/meta.ts src/components/toolbar/meta.ts src/foundation/meta.ts src/layout/app-shell/meta.ts src/layout/screen-section/meta.ts src/layout/screen/meta.ts src/layout/settings-layout/meta.ts src/layout/sidebar-layout/meta.ts src/layout/topbar-layout/meta.ts src/metadata/types.ts src/patterns/auth/meta.ts src/patterns/chat-list-item/meta.ts src/patterns/collection-editor/meta.ts src/patterns/confirm-dialog/meta.ts src/patterns/disclosure-section/meta.ts src/patterns/empty-state/meta.ts src/patterns/filter-bar/meta.ts src/patterns/hero/meta.ts src/patterns/image-preview/meta.ts src/patterns/image-upload-field/meta.ts src/patterns/inspector-field/meta.ts src/patterns/list/meta.ts src/patterns/message-bubble/meta.ts src/patterns/notice/meta.ts src/patterns/panel/meta.ts src/patterns/post-card/meta.ts src/patterns/responsive-panel/meta.ts src/patterns/section-header/meta.ts src/patterns/selection/meta.ts src/patterns/settings-row/meta.ts src/patterns/switch-field/meta.ts src/patterns/theme-composer/meta.ts src/patterns/tile-grid/meta.ts src/patterns/timeline/meta.ts src/patterns/tree-view/meta.ts src/patterns/zora-drawer-content/meta.ts src/patterns/zora-tab-bar/meta.ts ZORA_COMPONENT_META"
             >
               <h3>src/metadata/componentMeta.ts</h3>
               <p class="muted">Referenced module</p>
@@ -4068,6 +4127,7 @@
                 <code>src/components/avatar-group/meta.ts</code>,
                 <code>src/components/avatar/meta.ts</code>,
                 <code>src/components/badge/meta.ts</code>,
+                <code>src/components/breadcrumbs/meta.ts</code>,
                 <code>src/components/button-group/meta.ts</code>,
                 <code>src/components/button/meta.ts</code>,
                 <code>src/components/card/meta.ts</code>,
@@ -6845,6 +6905,172 @@
                       <td><code>variant</code></td>
                       <td>property</td>
                       <td><code>ZoraBadgeVariant | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+            </section>
+            <section>
+              <h3>src/components/breadcrumbs/Breadcrumbs.tsx</h3>
+              <article
+                class="item"
+                id="symbol-breadcrumbs"
+                data-search="Breadcrumbs value src/components/breadcrumbs/Breadcrumbs.tsx "
+              >
+                <h4>Breadcrumbs</h4>
+                <p class="muted">
+                  value • <code>src/components/breadcrumbs/Breadcrumbs.tsx:143:14</code>
+                </p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+              </article>
+            </section>
+            <section>
+              <h3>src/components/breadcrumbs/types.ts</h3>
+              <article
+                class="item"
+                id="symbol-breadcrumbitem"
+                data-search="BreadcrumbItem type src/components/breadcrumbs/types.ts "
+              >
+                <h4>BreadcrumbItem</h4>
+                <p class="muted">type • <code>src/components/breadcrumbs/types.ts:6:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>disabled</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>icon</code></td>
+                      <td>property</td>
+                      <td><code>ButtonIconSpec | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>id</code></td>
+                      <td>property</td>
+                      <td><code>string</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>label</code></td>
+                      <td>property</td>
+                      <td><code>React.ReactNode</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>onPress</code></td>
+                      <td>property</td>
+                      <td><code>(() =&gt; void) | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </article>
+              <article
+                class="item"
+                id="symbol-breadcrumbsprops"
+                data-search="BreadcrumbsProps type src/components/breadcrumbs/types.ts  BreadcrumbItem ZoraThemeMode"
+              >
+                <h4>BreadcrumbsProps</h4>
+                <p class="muted">type • <code>src/components/breadcrumbs/types.ts:14:1</code></p>
+
+                <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+                <div>
+                  <strong>Related symbols:</strong>
+                  <ul class="chips">
+                    <li class="chip">BreadcrumbItem</li>
+                    <li class="chip">ZoraThemeMode</li>
+                  </ul>
+                </div>
+
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Member</th>
+                      <th>Kind</th>
+                      <th>Type</th>
+                      <th>Required</th>
+                      <th>Description</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><code>compact</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>disabled</code></td>
+                      <td>property</td>
+                      <td><code>boolean | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>items</code></td>
+                      <td>property</td>
+                      <td><code>readonly BreadcrumbItem[]</code></td>
+                      <td>yes</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>maxItems</code></td>
+                      <td>property</td>
+                      <td><code>number | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>mode</code></td>
+                      <td>property</td>
+                      <td><code>ZoraThemeMode | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>separator</code></td>
+                      <td>property</td>
+                      <td><code>React.ReactNode</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>testID</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
+                      <td>no</td>
+                      <td></td>
+                    </tr>
+                    <tr>
+                      <td><code>themeId</code></td>
+                      <td>property</td>
+                      <td><code>string | undefined</code></td>
                       <td>no</td>
                       <td></td>
                     </tr>
@@ -20703,7 +20929,7 @@
                 data-search="ZORA_COMPONENT_META value src/metadata/componentMeta.ts "
               >
                 <h4>ZORA_COMPONENT_META</h4>
-                <p class="muted">value • <code>src/metadata/componentMeta.ts:86:14</code></p>
+                <p class="muted">value • <code>src/metadata/componentMeta.ts:87:14</code></p>
 
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
                 <div><strong>Related symbols:</strong> <span class="empty">None</span></div>
@@ -28597,6 +28823,76 @@
                   <tr>
                     <td><code>zIndex</code></td>
                     <td><code>Responsive&lt;number&gt; | undefined</code></td>
+                    <td>no</td>
+                    <td></td>
+                  </tr>
+                </tbody>
+              </table>
+            </article>
+            <article
+              class="item"
+              id="component-breadcrumbs"
+              data-search="Breadcrumbs src/components/breadcrumbs/Breadcrumbs.tsx  compact boolean | undefined disabled boolean | undefined items readonly BreadcrumbItem[] maxItems number | undefined mode ZoraThemeMode | undefined separator React.ReactNode testID string | undefined themeId string | undefined"
+            >
+              <h3>Breadcrumbs</h3>
+              <p class="muted"><code>src/components/breadcrumbs/Breadcrumbs.tsx:143:14</code></p>
+
+              <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Prop</th>
+                    <th>Type</th>
+                    <th>Required</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><code>compact</code></td>
+                    <td><code>boolean | undefined</code></td>
+                    <td>no</td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td><code>disabled</code></td>
+                    <td><code>boolean | undefined</code></td>
+                    <td>no</td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td><code>items</code></td>
+                    <td><code>readonly BreadcrumbItem[]</code></td>
+                    <td>yes</td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td><code>maxItems</code></td>
+                    <td><code>number | undefined</code></td>
+                    <td>no</td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td><code>mode</code></td>
+                    <td><code>ZoraThemeMode | undefined</code></td>
+                    <td>no</td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td><code>separator</code></td>
+                    <td><code>React.ReactNode</code></td>
+                    <td>no</td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td><code>testID</code></td>
+                    <td><code>string | undefined</code></td>
+                    <td>no</td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td><code>themeId</code></td>
+                    <td><code>string | undefined</code></td>
                     <td>no</td>
                     <td></td>
                   </tr>
@@ -41988,6 +42284,30 @@
                 package__ankhorage_zora -.-&gt; module_src_components_badge_types_ts
                 module_src_components_badge_types_ts --&gt; module_src_internal_recipes_ts
                 module_src_components_badge_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx[&quot;src/components/breadcrumbs/Breadcrumbs.tsx&quot;]
+                package__ankhorage_zora -.-&gt; module_src_components_breadcrumbs_Breadcrumbs_tsx
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_components_breadcrumbs_types_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_components_button_index_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_components_icon_index_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_components_text_index_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_foundation_index_ts module_src_components_breadcrumbs_Breadcrumbs_tsx
+                --&gt; module_src_internal_recipes_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_theme_useZoraTheme_ts module_src_components_breadcrumbs_Breadcrumbs_tsx
+                --&gt; module_src_theme_withZoraThemeScope_tsx
+                module_src_components_breadcrumbs_index_ts[&quot;src/components/breadcrumbs/index.ts&quot;]
+                package__ankhorage_zora -.-&gt; module_src_components_breadcrumbs_index_ts
+                module_src_components_breadcrumbs_meta_ts[&quot;src/components/breadcrumbs/meta.ts&quot;]
+                package__ankhorage_zora -.-&gt; module_src_components_breadcrumbs_meta_ts
+                module_src_components_breadcrumbs_meta_ts --&gt; module_src_metadata_index_ts
+                module_src_components_breadcrumbs_types_ts[&quot;src/components/breadcrumbs/types.ts&quot;]
+                package__ankhorage_zora -.-&gt; module_src_components_breadcrumbs_types_ts
+                module_src_components_breadcrumbs_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
                 module_src_components_button_group_ButtonGroup_tsx[&quot;src/components/button-group/ButtonGroup.tsx&quot;]
                 package__ankhorage_zora -.-&gt; module_src_components_button_group_ButtonGroup_tsx
                 module_src_components_button_group_ButtonGroup_tsx --&gt;
@@ -42863,47 +43183,49 @@
                 module_src_metadata_componentMeta_ts --&gt; module_src_components_avatar_meta_ts
                 module_src_metadata_componentMeta_ts --&gt; module_src_components_badge_meta_ts
                 module_src_metadata_componentMeta_ts --&gt;
-                module_src_components_button_group_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_button_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_card_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_checkbox_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_chip_group_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_chip_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_data_table_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_date_picker_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_drawer_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_form_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_heading_meta_ts
+                module_src_components_breadcrumbs_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_button_group_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_button_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_card_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_checkbox_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_chip_group_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_chip_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_data_table_meta_ts
                 module_src_metadata_componentMeta_ts --&gt;
-                module_src_components_icon_button_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_icon_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_image_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_input_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_media_card_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_menu_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_metric_card_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_modal_meta_ts
+                module_src_components_date_picker_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_drawer_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_form_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_heading_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_icon_button_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_icon_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_image_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_input_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_media_card_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_menu_meta_ts
                 module_src_metadata_componentMeta_ts --&gt;
-                module_src_components_navigation_item_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_navigation_list_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_pagination_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_progress_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_radio_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_rating_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_search_bar_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_select_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_skeleton_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_tabs_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_text_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_textarea_meta_ts
+                module_src_components_metric_card_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_modal_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_navigation_item_meta_ts
                 module_src_metadata_componentMeta_ts --&gt;
-                module_src_components_time_picker_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_toast_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_toolbar_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_foundation_meta_ts module_src_metadata_componentMeta_ts --&gt;
-                module_src_layout_app_shell_meta_ts module_src_metadata_componentMeta_ts --&gt;
-                module_src_layout_screen_section_meta_ts module_src_metadata_componentMeta_ts --&gt;
-                module_src_layout_screen_meta_ts module_src_metadata_componentMeta_ts --&gt;
+                module_src_components_navigation_list_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_pagination_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_progress_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_radio_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_rating_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_search_bar_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_select_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_skeleton_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_tabs_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_text_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_textarea_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_time_picker_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_toast_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_toolbar_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_foundation_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_layout_app_shell_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_layout_screen_section_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_layout_screen_meta_ts
+                module_src_metadata_componentMeta_ts --&gt;
                 module_src_layout_settings_layout_meta_ts module_src_metadata_componentMeta_ts
                 --&gt; module_src_layout_sidebar_layout_meta_ts module_src_metadata_componentMeta_ts
                 --&gt; module_src_layout_topbar_layout_meta_ts module_src_metadata_componentMeta_ts
@@ -43742,6 +44064,24 @@ graph TD
   package__ankhorage_zora -.-&gt; module_src_components_badge_types_ts
   module_src_components_badge_types_ts --&gt; module_src_internal_recipes_ts
   module_src_components_badge_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx[&quot;src/components/breadcrumbs/Breadcrumbs.tsx&quot;]
+  package__ankhorage_zora -.-&gt; module_src_components_breadcrumbs_Breadcrumbs_tsx
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_components_breadcrumbs_types_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_components_button_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_components_icon_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_components_text_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_foundation_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_internal_recipes_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_theme_useZoraTheme_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_theme_withZoraThemeScope_tsx
+  module_src_components_breadcrumbs_index_ts[&quot;src/components/breadcrumbs/index.ts&quot;]
+  package__ankhorage_zora -.-&gt; module_src_components_breadcrumbs_index_ts
+  module_src_components_breadcrumbs_meta_ts[&quot;src/components/breadcrumbs/meta.ts&quot;]
+  package__ankhorage_zora -.-&gt; module_src_components_breadcrumbs_meta_ts
+  module_src_components_breadcrumbs_meta_ts --&gt; module_src_metadata_index_ts
+  module_src_components_breadcrumbs_types_ts[&quot;src/components/breadcrumbs/types.ts&quot;]
+  package__ankhorage_zora -.-&gt; module_src_components_breadcrumbs_types_ts
+  module_src_components_breadcrumbs_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
   module_src_components_button_group_ButtonGroup_tsx[&quot;src/components/button-group/ButtonGroup.tsx&quot;]
   package__ankhorage_zora -.-&gt; module_src_components_button_group_ButtonGroup_tsx
   module_src_components_button_group_ButtonGroup_tsx --&gt; module_src_components_button_group_types_ts
@@ -44502,6 +44842,7 @@ graph TD
   module_src_metadata_componentMeta_ts --&gt; module_src_components_avatar_group_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_avatar_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_badge_meta_ts
+  module_src_metadata_componentMeta_ts --&gt; module_src_components_breadcrumbs_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_button_group_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_button_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_card_meta_ts
@@ -45172,6 +45513,10 @@ graph TD
                 module_src_components_badge_index_ts[&quot;src/components/badge/index.ts&quot;]
                 module_src_components_badge_meta_ts[&quot;src/components/badge/meta.ts&quot;]
                 module_src_components_badge_types_ts[&quot;src/components/badge/types.ts&quot;]
+                module_src_components_breadcrumbs_Breadcrumbs_tsx[&quot;src/components/breadcrumbs/Breadcrumbs.tsx&quot;]
+                module_src_components_breadcrumbs_index_ts[&quot;src/components/breadcrumbs/index.ts&quot;]
+                module_src_components_breadcrumbs_meta_ts[&quot;src/components/breadcrumbs/meta.ts&quot;]
+                module_src_components_breadcrumbs_types_ts[&quot;src/components/breadcrumbs/types.ts&quot;]
                 module_src_components_button_group_ButtonGroup_tsx[&quot;src/components/button-group/ButtonGroup.tsx&quot;]
                 module_src_components_button_group_index_ts[&quot;src/components/button-group/index.ts&quot;]
                 module_src_components_button_group_meta_ts[&quot;src/components/button-group/meta.ts&quot;]
@@ -45561,8 +45906,24 @@ graph TD
                 module_src_theme_withZoraThemeScope_tsx module_src_components_badge_meta_ts --&gt;
                 module_src_metadata_index_ts module_src_components_badge_types_ts --&gt;
                 module_src_internal_recipes_ts module_src_components_badge_types_ts --&gt;
-                module_src_theme_ZoraBaseProps_ts module_src_components_button_group_ButtonGroup_tsx
-                --&gt; module_src_components_button_group_types_ts
+                module_src_theme_ZoraBaseProps_ts module_src_components_breadcrumbs_Breadcrumbs_tsx
+                --&gt; module_src_components_breadcrumbs_types_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_components_button_index_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_components_icon_index_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_components_text_index_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_foundation_index_ts module_src_components_breadcrumbs_Breadcrumbs_tsx
+                --&gt; module_src_internal_recipes_ts
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt;
+                module_src_theme_useZoraTheme_ts module_src_components_breadcrumbs_Breadcrumbs_tsx
+                --&gt; module_src_theme_withZoraThemeScope_tsx
+                module_src_components_breadcrumbs_meta_ts --&gt; module_src_metadata_index_ts
+                module_src_components_breadcrumbs_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
+                module_src_components_button_group_ButtonGroup_tsx --&gt;
+                module_src_components_button_group_types_ts
                 module_src_components_button_group_ButtonGroup_tsx --&gt;
                 module_src_foundation_index_ts module_src_components_button_group_ButtonGroup_tsx
                 --&gt; module_src_theme_withZoraThemeScope_tsx
@@ -46018,47 +46379,49 @@ graph TD
                 module_src_metadata_componentMeta_ts --&gt; module_src_components_avatar_meta_ts
                 module_src_metadata_componentMeta_ts --&gt; module_src_components_badge_meta_ts
                 module_src_metadata_componentMeta_ts --&gt;
-                module_src_components_button_group_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_button_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_card_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_checkbox_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_chip_group_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_chip_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_data_table_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_date_picker_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_drawer_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_form_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_heading_meta_ts
+                module_src_components_breadcrumbs_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_button_group_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_button_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_card_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_checkbox_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_chip_group_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_chip_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_data_table_meta_ts
                 module_src_metadata_componentMeta_ts --&gt;
-                module_src_components_icon_button_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_icon_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_image_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_input_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_media_card_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_menu_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_metric_card_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_modal_meta_ts
+                module_src_components_date_picker_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_drawer_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_form_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_heading_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_icon_button_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_icon_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_image_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_input_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_media_card_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_menu_meta_ts
                 module_src_metadata_componentMeta_ts --&gt;
-                module_src_components_navigation_item_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_navigation_list_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_pagination_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_progress_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_radio_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_rating_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_search_bar_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_select_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_skeleton_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_tabs_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_text_meta_ts
-                module_src_metadata_componentMeta_ts --&gt; module_src_components_textarea_meta_ts
+                module_src_components_metric_card_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_modal_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_navigation_item_meta_ts
                 module_src_metadata_componentMeta_ts --&gt;
-                module_src_components_time_picker_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_toast_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_components_toolbar_meta_ts module_src_metadata_componentMeta_ts
-                --&gt; module_src_foundation_meta_ts module_src_metadata_componentMeta_ts --&gt;
-                module_src_layout_app_shell_meta_ts module_src_metadata_componentMeta_ts --&gt;
-                module_src_layout_screen_section_meta_ts module_src_metadata_componentMeta_ts --&gt;
-                module_src_layout_screen_meta_ts module_src_metadata_componentMeta_ts --&gt;
+                module_src_components_navigation_list_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_pagination_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_progress_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_radio_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_rating_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_search_bar_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_select_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_skeleton_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_tabs_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_text_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_textarea_meta_ts module_src_metadata_componentMeta_ts
+                --&gt; module_src_components_time_picker_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_toast_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_components_toolbar_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_foundation_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_layout_app_shell_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_layout_screen_section_meta_ts
+                module_src_metadata_componentMeta_ts --&gt; module_src_layout_screen_meta_ts
+                module_src_metadata_componentMeta_ts --&gt;
                 module_src_layout_settings_layout_meta_ts module_src_metadata_componentMeta_ts
                 --&gt; module_src_layout_sidebar_layout_meta_ts module_src_metadata_componentMeta_ts
                 --&gt; module_src_layout_topbar_layout_meta_ts module_src_metadata_componentMeta_ts
@@ -46531,6 +46894,10 @@ graph LR
   module_src_components_badge_index_ts[&quot;src/components/badge/index.ts&quot;]
   module_src_components_badge_meta_ts[&quot;src/components/badge/meta.ts&quot;]
   module_src_components_badge_types_ts[&quot;src/components/badge/types.ts&quot;]
+  module_src_components_breadcrumbs_Breadcrumbs_tsx[&quot;src/components/breadcrumbs/Breadcrumbs.tsx&quot;]
+  module_src_components_breadcrumbs_index_ts[&quot;src/components/breadcrumbs/index.ts&quot;]
+  module_src_components_breadcrumbs_meta_ts[&quot;src/components/breadcrumbs/meta.ts&quot;]
+  module_src_components_breadcrumbs_types_ts[&quot;src/components/breadcrumbs/types.ts&quot;]
   module_src_components_button_group_ButtonGroup_tsx[&quot;src/components/button-group/ButtonGroup.tsx&quot;]
   module_src_components_button_group_index_ts[&quot;src/components/button-group/index.ts&quot;]
   module_src_components_button_group_meta_ts[&quot;src/components/button-group/meta.ts&quot;]
@@ -46907,6 +47274,16 @@ graph LR
   module_src_components_badge_meta_ts --&gt; module_src_metadata_index_ts
   module_src_components_badge_types_ts --&gt; module_src_internal_recipes_ts
   module_src_components_badge_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_components_breadcrumbs_types_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_components_button_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_components_icon_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_components_text_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_foundation_index_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_internal_recipes_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_theme_useZoraTheme_ts
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; module_src_theme_withZoraThemeScope_tsx
+  module_src_components_breadcrumbs_meta_ts --&gt; module_src_metadata_index_ts
+  module_src_components_breadcrumbs_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
   module_src_components_button_group_ButtonGroup_tsx --&gt; module_src_components_button_group_types_ts
   module_src_components_button_group_ButtonGroup_tsx --&gt; module_src_foundation_index_ts
   module_src_components_button_group_ButtonGroup_tsx --&gt; module_src_theme_withZoraThemeScope_tsx
@@ -47278,6 +47655,7 @@ graph LR
   module_src_metadata_componentMeta_ts --&gt; module_src_components_avatar_group_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_avatar_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_badge_meta_ts
+  module_src_metadata_componentMeta_ts --&gt; module_src_components_breadcrumbs_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_button_group_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_button_meta_ts
   module_src_metadata_componentMeta_ts --&gt; module_src_components_card_meta_ts
@@ -47673,6 +48051,10 @@ graph LR
                 module_src_components_badge_index_ts[&quot;src/components/badge/index.ts&quot;]
                 module_src_components_badge_meta_ts[&quot;src/components/badge/meta.ts&quot;]
                 module_src_components_badge_types_ts[&quot;src/components/badge/types.ts&quot;]
+                module_src_components_breadcrumbs_Breadcrumbs_tsx[&quot;src/components/breadcrumbs/Breadcrumbs.tsx&quot;]
+                module_src_components_breadcrumbs_index_ts[&quot;src/components/breadcrumbs/index.ts&quot;]
+                module_src_components_breadcrumbs_meta_ts[&quot;src/components/breadcrumbs/meta.ts&quot;]
+                module_src_components_breadcrumbs_types_ts[&quot;src/components/breadcrumbs/types.ts&quot;]
                 module_src_components_button_group_ButtonGroup_tsx[&quot;src/components/button-group/ButtonGroup.tsx&quot;]
                 module_src_components_button_group_index_ts[&quot;src/components/button-group/index.ts&quot;]
                 module_src_components_button_group_meta_ts[&quot;src/components/button-group/meta.ts&quot;]
@@ -48054,8 +48436,16 @@ graph LR
                 export_Box[&quot;Box&quot;] module_src_foundation_Box_tsx --&gt; export_Box
                 export_BoxProps[&quot;BoxProps&quot;] module_src_foundation_Box_tsx --&gt;
                 export_BoxProps export_BoxProps -.-&gt; export_ZoraThemeMode
-                export_Button[&quot;Button&quot;] module_src_components_button_Button_tsx --&gt;
-                export_Button export_ButtonGroup[&quot;ButtonGroup&quot;]
+                export_BreadcrumbItem[&quot;BreadcrumbItem&quot;]
+                module_src_components_breadcrumbs_types_ts --&gt; export_BreadcrumbItem
+                export_Breadcrumbs[&quot;Breadcrumbs&quot;]
+                module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; export_Breadcrumbs
+                export_BreadcrumbsProps[&quot;BreadcrumbsProps&quot;]
+                module_src_components_breadcrumbs_types_ts --&gt; export_BreadcrumbsProps
+                export_BreadcrumbsProps -.-&gt; export_BreadcrumbItem export_BreadcrumbsProps
+                -.-&gt; export_ZoraThemeMode export_Button[&quot;Button&quot;]
+                module_src_components_button_Button_tsx --&gt; export_Button
+                export_ButtonGroup[&quot;ButtonGroup&quot;]
                 module_src_components_button_group_ButtonGroup_tsx --&gt; export_ButtonGroup
                 export_ButtonGroupAlign[&quot;ButtonGroupAlign&quot;]
                 module_src_components_button_group_types_ts --&gt; export_ButtonGroupAlign
@@ -48840,6 +49230,10 @@ graph LR
   module_src_components_badge_index_ts[&quot;src/components/badge/index.ts&quot;]
   module_src_components_badge_meta_ts[&quot;src/components/badge/meta.ts&quot;]
   module_src_components_badge_types_ts[&quot;src/components/badge/types.ts&quot;]
+  module_src_components_breadcrumbs_Breadcrumbs_tsx[&quot;src/components/breadcrumbs/Breadcrumbs.tsx&quot;]
+  module_src_components_breadcrumbs_index_ts[&quot;src/components/breadcrumbs/index.ts&quot;]
+  module_src_components_breadcrumbs_meta_ts[&quot;src/components/breadcrumbs/meta.ts&quot;]
+  module_src_components_breadcrumbs_types_ts[&quot;src/components/breadcrumbs/types.ts&quot;]
   module_src_components_button_group_ButtonGroup_tsx[&quot;src/components/button-group/ButtonGroup.tsx&quot;]
   module_src_components_button_group_index_ts[&quot;src/components/button-group/index.ts&quot;]
   module_src_components_button_group_meta_ts[&quot;src/components/button-group/meta.ts&quot;]
@@ -49233,6 +49627,14 @@ graph LR
   export_BoxProps[&quot;BoxProps&quot;]
   module_src_foundation_Box_tsx --&gt; export_BoxProps
   export_BoxProps -.-&gt; export_ZoraThemeMode
+  export_BreadcrumbItem[&quot;BreadcrumbItem&quot;]
+  module_src_components_breadcrumbs_types_ts --&gt; export_BreadcrumbItem
+  export_Breadcrumbs[&quot;Breadcrumbs&quot;]
+  module_src_components_breadcrumbs_Breadcrumbs_tsx --&gt; export_Breadcrumbs
+  export_BreadcrumbsProps[&quot;BreadcrumbsProps&quot;]
+  module_src_components_breadcrumbs_types_ts --&gt; export_BreadcrumbsProps
+  export_BreadcrumbsProps -.-&gt; export_BreadcrumbItem
+  export_BreadcrumbsProps -.-&gt; export_ZoraThemeMode
   export_Button[&quot;Button&quot;]
   module_src_components_button_Button_tsx --&gt; export_Button
   export_ButtonGroup[&quot;ButtonGroup&quot;]
@@ -50584,6 +50986,56 @@ sequenceDiagram
             <article class="item" data-search="BadgeInner src/components/badge/Badge.tsx ">
               <h3>BadgeInner</h3>
               <p class="muted"><code>src/components/badge/Badge.tsx:8:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+          </section>
+        </section>
+        <section
+          id="view-src-components-breadcrumbs-breadcrumbs-tsx"
+          class="view"
+          data-view="src/components/breadcrumbs/Breadcrumbs.tsx"
+          hidden
+        >
+          <section class="panel">
+            <h2>src/components/breadcrumbs/Breadcrumbs.tsx</h2>
+            <article
+              class="item"
+              data-search="normalizeMaxItems src/components/breadcrumbs/Breadcrumbs.tsx "
+            >
+              <h3>normalizeMaxItems</h3>
+              <p class="muted"><code>src/components/breadcrumbs/Breadcrumbs.tsx:21:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article
+              class="item"
+              data-search="createRenderItems src/components/breadcrumbs/Breadcrumbs.tsx "
+            >
+              <h3>createRenderItems</h3>
+              <p class="muted"><code>src/components/breadcrumbs/Breadcrumbs.tsx:29:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article
+              class="item"
+              data-search="renderSeparator src/components/breadcrumbs/Breadcrumbs.tsx "
+            >
+              <h3>renderSeparator</h3>
+              <p class="muted"><code>src/components/breadcrumbs/Breadcrumbs.tsx:52:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article
+              class="item"
+              data-search="BreadcrumbLabel src/components/breadcrumbs/Breadcrumbs.tsx "
+            >
+              <h3>BreadcrumbLabel</h3>
+              <p class="muted"><code>src/components/breadcrumbs/Breadcrumbs.tsx:60:1</code></p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article
+              class="item"
+              data-search="BreadcrumbsInner src/components/breadcrumbs/Breadcrumbs.tsx "
+            >
+              <h3>BreadcrumbsInner</h3>
+              <p class="muted"><code>src/components/breadcrumbs/Breadcrumbs.tsx:80:1</code></p>
               <p class="empty">No description available.</p>
             </article>
           </section>

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -232,6 +232,39 @@
       "exports": ["BadgeProps"]
     },
     {
+      "path": "src/components/breadcrumbs/Breadcrumbs.tsx",
+      "isEntrypoint": false,
+      "dependencies": [
+        "src/components/breadcrumbs/types.ts",
+        "src/components/button/index.ts",
+        "src/components/icon/index.ts",
+        "src/components/text/index.ts",
+        "src/foundation/index.ts",
+        "src/internal/recipes.ts",
+        "src/theme/useZoraTheme.ts",
+        "src/theme/withZoraThemeScope.tsx"
+      ],
+      "exports": ["Breadcrumbs"]
+    },
+    {
+      "path": "src/components/breadcrumbs/index.ts",
+      "isEntrypoint": false,
+      "dependencies": [],
+      "exports": ["BreadcrumbItem", "Breadcrumbs", "BreadcrumbsProps"]
+    },
+    {
+      "path": "src/components/breadcrumbs/meta.ts",
+      "isEntrypoint": false,
+      "dependencies": ["src/metadata/index.ts"],
+      "exports": ["breadcrumbsMeta"]
+    },
+    {
+      "path": "src/components/breadcrumbs/types.ts",
+      "isEntrypoint": false,
+      "dependencies": ["src/theme/ZoraBaseProps.ts"],
+      "exports": ["BreadcrumbItem", "BreadcrumbsProps"]
+    },
+    {
       "path": "src/components/button-group/ButtonGroup.tsx",
       "isEntrypoint": false,
       "dependencies": [
@@ -1644,6 +1677,9 @@
         "BadgeProps",
         "Box",
         "BoxProps",
+        "BreadcrumbItem",
+        "Breadcrumbs",
+        "BreadcrumbsProps",
         "Button",
         "ButtonGroup",
         "ButtonGroupAlign",
@@ -2217,6 +2253,7 @@
         "src/components/avatar-group/meta.ts",
         "src/components/avatar/meta.ts",
         "src/components/badge/meta.ts",
+        "src/components/breadcrumbs/meta.ts",
         "src/components/button-group/meta.ts",
         "src/components/button/meta.ts",
         "src/components/card/meta.ts",
@@ -4882,6 +4919,153 @@
           "name": "zIndex",
           "kind": "property",
           "type": "Responsive<number> | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "BreadcrumbItem",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/components/breadcrumbs/types.ts",
+      "sourceLocation": {
+        "filePath": "src/components/breadcrumbs/types.ts",
+        "line": 6,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [
+        {
+          "name": "disabled",
+          "kind": "property",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "icon",
+          "kind": "property",
+          "type": "ButtonIconSpec | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "id",
+          "kind": "property",
+          "type": "string",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "label",
+          "kind": "property",
+          "type": "React.ReactNode",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "onPress",
+          "kind": "property",
+          "type": "(() => void) | undefined",
+          "required": false,
+          "description": null
+        }
+      ],
+      "structuredRows": []
+    },
+    {
+      "name": "Breadcrumbs",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "value",
+      "modulePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+      "sourceLocation": {
+        "filePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "line": 143,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": [],
+      "signatures": [],
+      "members": [],
+      "structuredRows": []
+    },
+    {
+      "name": "BreadcrumbsProps",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "kind": "type",
+      "modulePath": "src/components/breadcrumbs/types.ts",
+      "sourceLocation": {
+        "filePath": "src/components/breadcrumbs/types.ts",
+        "line": 14,
+        "column": 1
+      },
+      "exportPaths": ["src/index.ts"],
+      "relatedSymbols": ["BreadcrumbItem", "ZoraThemeMode"],
+      "signatures": [],
+      "members": [
+        {
+          "name": "compact",
+          "kind": "property",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "disabled",
+          "kind": "property",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "items",
+          "kind": "property",
+          "type": "readonly BreadcrumbItem[]",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "maxItems",
+          "kind": "property",
+          "type": "number | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "mode",
+          "kind": "property",
+          "type": "ZoraThemeMode | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "separator",
+          "kind": "property",
+          "type": "React.ReactNode",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "testID",
+          "kind": "property",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "themeId",
+          "kind": "property",
+          "type": "string | undefined",
           "required": false,
           "description": null
         }
@@ -21716,7 +21900,7 @@
       "modulePath": "src/metadata/componentMeta.ts",
       "sourceLocation": {
         "filePath": "src/metadata/componentMeta.ts",
-        "line": 86,
+        "line": 87,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -24006,6 +24190,69 @@
         {
           "name": "zIndex",
           "type": "Responsive<number> | undefined",
+          "required": false,
+          "description": null
+        }
+      ]
+    },
+    {
+      "name": "Breadcrumbs",
+      "description": null,
+      "isReadme": false,
+      "examples": [],
+      "modulePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+      "sourceLocation": {
+        "filePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "line": 143,
+        "column": 14
+      },
+      "exportPaths": ["src/index.ts"],
+      "props": [
+        {
+          "name": "compact",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "disabled",
+          "type": "boolean | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "items",
+          "type": "readonly BreadcrumbItem[]",
+          "required": true,
+          "description": null
+        },
+        {
+          "name": "maxItems",
+          "type": "number | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "mode",
+          "type": "ZoraThemeMode | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "separator",
+          "type": "React.ReactNode",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "testID",
+          "type": "string | undefined",
+          "required": false,
+          "description": null
+        },
+        {
+          "name": "themeId",
+          "type": "string | undefined",
           "required": false,
           "description": null
         }
@@ -35855,6 +36102,51 @@
       }
     },
     {
+      "name": "normalizeMaxItems",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "line": 21,
+        "column": 1
+      }
+    },
+    {
+      "name": "createRenderItems",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "line": 29,
+        "column": 1
+      }
+    },
+    {
+      "name": "renderSeparator",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "line": 52,
+        "column": 1
+      }
+    },
+    {
+      "name": "BreadcrumbLabel",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "line": 60,
+        "column": 1
+      }
+    },
+    {
+      "name": "BreadcrumbsInner",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "line": 80,
+        "column": 1
+      }
+    },
+    {
       "name": "resolveDirection",
       "description": null,
       "sourceLocation": {
@@ -38578,6 +38870,11 @@
       },
       {
         "fromPath": "src/index.ts",
+        "toPath": "src/components/breadcrumbs/index.ts",
+        "sourcePath": "src/index.ts"
+      },
+      {
+        "fromPath": "src/index.ts",
         "toPath": "src/components/button/index.ts",
         "sourcePath": "src/index.ts"
       },
@@ -39129,6 +39426,11 @@
       {
         "fromPath": "src/metadata/componentMeta.ts",
         "toPath": "src/components/badge/meta.ts",
+        "sourcePath": "src/metadata/componentMeta.ts"
+      },
+      {
+        "fromPath": "src/metadata/componentMeta.ts",
+        "toPath": "src/components/breadcrumbs/meta.ts",
         "sourcePath": "src/metadata/componentMeta.ts"
       },
       {
@@ -39895,6 +40197,66 @@
         "fromPath": "src/components/badge/types.ts",
         "toPath": "src/theme/ZoraBaseProps.ts",
         "sourcePath": "src/components/badge/types.ts"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toPath": "src/foundation/index.ts",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toPath": "src/internal/recipes.ts",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toPath": "src/theme/useZoraTheme.ts",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toPath": "src/theme/withZoraThemeScope.tsx",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toPath": "src/components/button/index.ts",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toPath": "src/components/icon/index.ts",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toPath": "src/components/text/index.ts",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toPath": "src/components/breadcrumbs/types.ts",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/index.ts",
+        "toPath": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "sourcePath": "src/components/breadcrumbs/index.ts"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/index.ts",
+        "toPath": "src/components/breadcrumbs/types.ts",
+        "sourcePath": "src/components/breadcrumbs/index.ts"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/meta.ts",
+        "toPath": "src/metadata/index.ts",
+        "sourcePath": "src/components/breadcrumbs/meta.ts"
+      },
+      {
+        "fromPath": "src/components/breadcrumbs/types.ts",
+        "toPath": "src/theme/ZoraBaseProps.ts",
+        "sourcePath": "src/components/breadcrumbs/types.ts"
       },
       {
         "fromPath": "src/components/button/Button.tsx",
@@ -44081,6 +44443,42 @@
         "sourcePath": "src/components/badge/Badge.tsx"
       },
       {
+        "fromSymbol": "BreadcrumbLabel",
+        "toSymbol": "useZoraTheme",
+        "callExpression": "useZoraTheme",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromSymbol": "BreadcrumbLabel",
+        "toSymbol": "resolveIconSize",
+        "callExpression": "resolveIconSize",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromSymbol": "BreadcrumbsInner",
+        "toSymbol": "normalizeMaxItems",
+        "callExpression": "normalizeMaxItems",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromSymbol": "BreadcrumbsInner",
+        "toSymbol": "createRenderItems",
+        "callExpression": "createRenderItems",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromSymbol": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toSymbol": "renderSeparator",
+        "callExpression": "renderSeparator",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
+        "fromSymbol": "src/components/breadcrumbs/Breadcrumbs.tsx",
+        "toSymbol": "withZoraThemeScope",
+        "callExpression": "withZoraThemeScope",
+        "sourcePath": "src/components/breadcrumbs/Breadcrumbs.tsx"
+      },
+      {
         "fromSymbol": "ButtonInner",
         "toSymbol": "resolveButtonRecipe",
         "callExpression": "resolveButtonRecipe",
@@ -46644,6 +47042,41 @@
         "fromSymbol": "BadgeProps",
         "toType": "ZoraThemeMode",
         "sourcePath": "src/components/badge/types.ts"
+      },
+      {
+        "fromSymbol": "BreadcrumbItem",
+        "toType": "ButtonIconSpec",
+        "sourcePath": "src/components/breadcrumbs/types.ts"
+      },
+      {
+        "fromSymbol": "BreadcrumbItem",
+        "toType": "React",
+        "sourcePath": "src/components/breadcrumbs/types.ts"
+      },
+      {
+        "fromSymbol": "BreadcrumbItem",
+        "toType": "ReactNode",
+        "sourcePath": "src/components/breadcrumbs/types.ts"
+      },
+      {
+        "fromSymbol": "BreadcrumbsProps",
+        "toType": "BreadcrumbItem",
+        "sourcePath": "src/components/breadcrumbs/types.ts"
+      },
+      {
+        "fromSymbol": "BreadcrumbsProps",
+        "toType": "React",
+        "sourcePath": "src/components/breadcrumbs/types.ts"
+      },
+      {
+        "fromSymbol": "BreadcrumbsProps",
+        "toType": "ReactNode",
+        "sourcePath": "src/components/breadcrumbs/types.ts"
+      },
+      {
+        "fromSymbol": "BreadcrumbsProps",
+        "toType": "ZoraThemeMode",
+        "sourcePath": "src/components/breadcrumbs/types.ts"
       },
       {
         "fromSymbol": "ButtonProps",

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -34,11 +34,16 @@ function createRenderItems(
     return items.map((item) => ({ item, type: 'item' }));
   }
 
+  const [firstItem] = items;
+  if (firstItem === undefined) {
+    return [];
+  }
+
   const trailingCount = maxItems - 2;
   const trailingItems = items.slice(items.length - trailingCount);
 
   return [
-    { item: items[0], type: 'item' },
+    { item: firstItem, type: 'item' },
     { type: 'ellipsis' },
     ...trailingItems.map((item) => ({ item, type: 'item' }) satisfies BreadcrumbRenderItem),
   ];

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -107,7 +107,7 @@ function BreadcrumbsInner({
           );
         }
 
-        const item = renderItem.item;
+        const { item } = renderItem;
         const current = item.id === currentItemId;
         const interactive = !current && !disabled && !item.disabled && Boolean(item.onPress);
 
@@ -116,7 +116,6 @@ function BreadcrumbsInner({
             {interactive ? (
               <Button
                 color="neutral"
-                disabled={disabled || item.disabled}
                 leadingIcon={item.icon}
                 onPress={item.onPress}
                 size={compact ? 's' : 'm'}

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -9,10 +9,14 @@ import { Icon } from '../icon';
 import { Text } from '../text';
 import type { BreadcrumbItem, BreadcrumbsProps } from './types';
 
-interface BreadcrumbRenderItem {
-  item?: BreadcrumbItem;
-  type: 'item' | 'ellipsis';
-}
+type BreadcrumbRenderItem =
+  | {
+      item: BreadcrumbItem;
+      type: 'item';
+    }
+  | {
+      type: 'ellipsis';
+    };
 
 function normalizeMaxItems(value: number | undefined): number | undefined {
   if (value === undefined || !Number.isFinite(value)) {
@@ -104,10 +108,6 @@ function BreadcrumbsInner({
         }
 
         const item = renderItem.item;
-        if (!item) {
-          return null;
-        }
-
         const current = item.id === currentItemId;
         const interactive = !current && !disabled && !item.disabled && Boolean(item.onPress);
 

--- a/src/components/breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/breadcrumbs/Breadcrumbs.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+
+import { Inline } from '../../foundation';
+import { resolveIconSize } from '../../internal/recipes';
+import { useZoraTheme } from '../../theme/useZoraTheme';
+import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
+import { Button } from '../button';
+import { Icon } from '../icon';
+import { Text } from '../text';
+import type { BreadcrumbItem, BreadcrumbsProps } from './types';
+
+interface BreadcrumbRenderItem {
+  item?: BreadcrumbItem;
+  type: 'item' | 'ellipsis';
+}
+
+function normalizeMaxItems(value: number | undefined): number | undefined {
+  if (value === undefined || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.trunc(value));
+}
+
+function createRenderItems(
+  items: readonly BreadcrumbItem[],
+  maxItems: number | undefined,
+): readonly BreadcrumbRenderItem[] {
+  if (maxItems === undefined || maxItems === 0 || items.length <= maxItems || maxItems < 3) {
+    return items.map((item) => ({ item, type: 'item' }));
+  }
+
+  const trailingCount = maxItems - 2;
+  const trailingItems = items.slice(items.length - trailingCount);
+
+  return [
+    { item: items[0], type: 'item' },
+    { type: 'ellipsis' },
+    ...trailingItems.map((item) => ({ item, type: 'item' }) satisfies BreadcrumbRenderItem),
+  ];
+}
+
+function renderSeparator(separator: React.ReactNode) {
+  return (
+    <Text emphasis="muted" variant="bodySmall">
+      {separator}
+    </Text>
+  );
+}
+
+function BreadcrumbLabel({ item, compact }: { item: BreadcrumbItem; compact: boolean }) {
+  const { theme } = useZoraTheme();
+
+  return (
+    <Inline align="center" gap="xs" wrap="nowrap">
+      {item.icon ? (
+        <Icon
+          color={theme.semantics.content.muted}
+          name={item.icon.name}
+          provider={item.icon.provider}
+          size={resolveIconSize(compact ? 's' : 'm')}
+        />
+      ) : null}
+      <Text emphasis="muted" variant={compact ? 'caption' : 'bodySmall'}>
+        {item.label}
+      </Text>
+    </Inline>
+  );
+}
+
+function BreadcrumbsInner({
+  themeId: _themeId,
+  mode: _mode,
+  items,
+  separator = '/',
+  maxItems,
+  compact = false,
+  disabled = false,
+  testID,
+}: BreadcrumbsProps) {
+  const normalizedMaxItems = normalizeMaxItems(maxItems);
+  const renderItems = createRenderItems(items, normalizedMaxItems);
+  const currentItemId = items.at(-1)?.id;
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <Inline align="center" gap={compact ? 'xs' : 's'} testID={testID} wrap="wrap">
+      {renderItems.map((renderItem, index) => {
+        const isLastRenderedItem = index === renderItems.length - 1;
+        const showSeparator = !isLastRenderedItem;
+
+        if (renderItem.type === 'ellipsis') {
+          return (
+            <React.Fragment key="ellipsis">
+              <Text emphasis="muted" variant={compact ? 'caption' : 'bodySmall'}>
+                …
+              </Text>
+              {showSeparator ? renderSeparator(separator) : null}
+            </React.Fragment>
+          );
+        }
+
+        const item = renderItem.item;
+        if (!item) {
+          return null;
+        }
+
+        const current = item.id === currentItemId;
+        const interactive = !current && !disabled && !item.disabled && Boolean(item.onPress);
+
+        return (
+          <React.Fragment key={item.id}>
+            {interactive ? (
+              <Button
+                color="neutral"
+                disabled={disabled || item.disabled}
+                leadingIcon={item.icon}
+                onPress={item.onPress}
+                size={compact ? 's' : 'm'}
+                testID={testID ? `${testID}-item-${item.id}` : undefined}
+                variant="ghost"
+              >
+                {item.label}
+              </Button>
+            ) : (
+              <BreadcrumbLabel item={item} compact={compact} />
+            )}
+            {showSeparator ? renderSeparator(separator) : null}
+          </React.Fragment>
+        );
+      })}
+    </Inline>
+  );
+}
+
+export const Breadcrumbs = withZoraThemeScope(BreadcrumbsInner);

--- a/src/components/breadcrumbs/index.ts
+++ b/src/components/breadcrumbs/index.ts
@@ -1,0 +1,2 @@
+export { Breadcrumbs } from './Breadcrumbs';
+export type { BreadcrumbItem, BreadcrumbsProps } from './types';

--- a/src/components/breadcrumbs/meta.ts
+++ b/src/components/breadcrumbs/meta.ts
@@ -1,0 +1,10 @@
+import type { ZoraComponentMeta } from '../../metadata';
+
+export const breadcrumbsMeta = {
+  name: 'Breadcrumbs',
+  category: 'component',
+  directManifestNode: false,
+  allowedChildren: [],
+  note: 'Code-facing route hierarchy component; not represented as a manifest node in v1.',
+  props: {},
+} as const satisfies ZoraComponentMeta;

--- a/src/components/breadcrumbs/types.ts
+++ b/src/components/breadcrumbs/types.ts
@@ -1,0 +1,21 @@
+import type { ButtonIconSpec } from '@ankhorage/surface';
+import type React from 'react';
+
+import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
+
+export interface BreadcrumbItem {
+  id: string;
+  label: React.ReactNode;
+  icon?: ButtonIconSpec;
+  onPress?: () => void;
+  disabled?: boolean;
+}
+
+export interface BreadcrumbsProps extends ZoraBaseProps {
+  items: readonly BreadcrumbItem[];
+  separator?: React.ReactNode;
+  maxItems?: number;
+  compact?: boolean;
+  disabled?: boolean;
+  testID?: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ export type { AvatarGroupItem, AvatarGroupProps } from './components/avatar-grou
 export { AvatarGroup } from './components/avatar-group';
 export type { BadgeProps } from './components/badge';
 export { Badge } from './components/badge';
+export type { BreadcrumbItem, BreadcrumbsProps } from './components/breadcrumbs';
+export { Breadcrumbs } from './components/breadcrumbs';
 export type { ButtonProps } from './components/button';
 export { Button } from './components/button';
 export type {

--- a/src/metadata/componentMeta.ts
+++ b/src/metadata/componentMeta.ts
@@ -3,6 +3,7 @@ import { appBarMeta } from '../components/app-bar/meta';
 import { avatarMeta } from '../components/avatar/meta';
 import { avatarGroupMeta } from '../components/avatar-group/meta';
 import { badgeMeta } from '../components/badge/meta';
+import { breadcrumbsMeta } from '../components/breadcrumbs/meta';
 import { buttonMeta } from '../components/button/meta';
 import { buttonGroupMeta } from '../components/button-group/meta';
 import { cardMeta } from '../components/card/meta';
@@ -91,6 +92,7 @@ export const ZORA_COMPONENT_META: ZoraComponentMetaRegistry = {
   Avatar: avatarMeta,
   AvatarGroup: avatarGroupMeta,
   Badge: badgeMeta,
+  Breadcrumbs: breadcrumbsMeta,
   Button: buttonMeta,
   ButtonGroup: buttonGroupMeta,
   Card: cardMeta,


### PR DESCRIPTION
## Summary

- add `Breadcrumbs` for app-facing hierarchy trails
- add `BreadcrumbItem` and `BreadcrumbsProps` public types
- render the last item as the current non-interactive page
- render previous items as ghost buttons when `onPress` exists
- support optional icons, custom separators, compact mode, disabled state, and `maxItems` collapse
- export the component and types from the root barrel
- register `Breadcrumbs` in `ZORA_COMPONENT_META`
- add a patch changeset

Closes #220.

## Boundary

This is ZORA-first. No Surface breadcrumb primitive is introduced.

## Verification

Please run before merge:

```bash
bun install
bun run knip
bun run lint
bun run build
bun run test
```