### PR TITLE
feat(metadata): register Progress as manifest node

### DIFF
--- a/.changeset/clean-progress-metadata.md
+++ b/.changeset/clean-progress-metadata.md
@@ -1,0 +1,5 @@
+---
+"@ankhorage/zora": patch
+---
+
+Register `Progress` as a direct manifest-capable ZORA component with serializable metadata props and blueprint defaults.

--- a/.changeset/clean-progress-metadata.md
+++ b/.changeset/clean-progress-metadata.md
@@ -1,5 +1,5 @@
 ---
-"@ankhorage/zora": patch
+'@ankhorage/zora': patch
 ---
 
 Register `Progress` as a direct manifest-capable ZORA component with serializable metadata props and blueprint defaults.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # ZORA
 
-![license: MIT](././paradox/badges/license.svg) ![npm: v2.5.5](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
+![license: MIT](././paradox/badges/license.svg) ![npm: v2.6.0](././paradox/badges/npm.svg) ![runtime: bun](././paradox/badges/runtime.svg) ![typescript: strict](././paradox/badges/typescript.svg) ![eslint: checked](././paradox/badges/eslint.svg) ![prettier: checked](././paradox/badges/prettier.svg) ![build: checked](././paradox/badges/build.svg) ![tests: checked](././paradox/badges/tests.svg) ![docs: paradox](././paradox/badges/docs.svg)
 
 Opinionated React Native and React Native Web UI kit built on @ankhorage/surface.
 

--- a/paradox/badges/npm.svg
+++ b/paradox/badges/npm.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="npm: v2.5.5">
-<title>npm: v2.5.5</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="npm: v2.6.0">
+<title>npm: v2.6.0</title>
 <rect width="38" height="20" fill="#374151"/>
 <rect x="38" width="52" height="20" fill="#cb3837"/>
 <text x="19" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">npm</text>
-<text x="64" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v2.5.5</text>
+<text x="64" y="14" fill="#ffffff" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11" text-anchor="middle">v2.6.0</text>
 </svg>

--- a/paradox/diagrams/architecture-overview.mmd
+++ b/paradox/diagrams/architecture-overview.mmd
@@ -514,6 +514,7 @@ graph TD
   package__ankhorage_zora -.-> module_src_components_progress_index_ts
   module_src_components_progress_meta_ts["src/components/progress/meta.ts"]
   package__ankhorage_zora -.-> module_src_components_progress_meta_ts
+  module_src_components_progress_meta_ts --> module_src_internal_colorModel_ts
   module_src_components_progress_meta_ts --> module_src_metadata_index_ts
   module_src_components_progress_Progress_tsx["src/components/progress/Progress.tsx"]
   package__ankhorage_zora -.-> module_src_components_progress_Progress_tsx

--- a/paradox/diagrams/module-relationships.mmd
+++ b/paradox/diagrams/module-relationships.mmd
@@ -624,6 +624,7 @@ graph LR
   module_src_components_pagination_Pagination_tsx --> module_src_foundation_index_ts
   module_src_components_pagination_Pagination_tsx --> module_src_theme_withZoraThemeScope_tsx
   module_src_components_pagination_types_ts --> module_src_theme_ZoraBaseProps_ts
+  module_src_components_progress_meta_ts --> module_src_internal_colorModel_ts
   module_src_components_progress_meta_ts --> module_src_metadata_index_ts
   module_src_components_progress_Progress_tsx --> module_src_components_progress_resolveProgressFraction_ts
   module_src_components_progress_Progress_tsx --> module_src_components_progress_types_ts

--- a/paradox/index.html
+++ b/paradox/index.html
@@ -2916,11 +2916,14 @@
             </article>
             <article
               class="item"
-              data-search="src/components/progress/meta.ts src/metadata/index.ts progressMeta"
+              data-search="src/components/progress/meta.ts src/internal/colorModel.ts src/metadata/index.ts progressMeta"
             >
               <h3>src/components/progress/meta.ts</h3>
               <p class="muted">Referenced module</p>
-              <p><strong>Dependencies:</strong> <code>src/metadata/index.ts</code></p>
+              <p>
+                <strong>Dependencies:</strong> <code>src/internal/colorModel.ts</code>,
+                <code>src/metadata/index.ts</code>
+              </p>
               <p><strong>Exports:</strong> <code>progressMeta</code></p>
             </article>
             <article
@@ -44594,6 +44597,7 @@
                 package__ankhorage_zora -.-&gt; module_src_components_progress_index_ts
                 module_src_components_progress_meta_ts[&quot;src/components/progress/meta.ts&quot;]
                 package__ankhorage_zora -.-&gt; module_src_components_progress_meta_ts
+                module_src_components_progress_meta_ts --&gt; module_src_internal_colorModel_ts
                 module_src_components_progress_meta_ts --&gt; module_src_metadata_index_ts
                 module_src_components_progress_Progress_tsx[&quot;src/components/progress/Progress.tsx&quot;]
                 package__ankhorage_zora -.-&gt; module_src_components_progress_Progress_tsx
@@ -46372,6 +46376,7 @@ graph TD
   package__ankhorage_zora -.-&gt; module_src_components_progress_index_ts
   module_src_components_progress_meta_ts[&quot;src/components/progress/meta.ts&quot;]
   package__ankhorage_zora -.-&gt; module_src_components_progress_meta_ts
+  module_src_components_progress_meta_ts --&gt; module_src_internal_colorModel_ts
   module_src_components_progress_meta_ts --&gt; module_src_metadata_index_ts
   module_src_components_progress_Progress_tsx[&quot;src/components/progress/Progress.tsx&quot;]
   package__ankhorage_zora -.-&gt; module_src_components_progress_Progress_tsx
@@ -48119,6 +48124,7 @@ graph TD
                 module_src_components_pagination_Pagination_tsx --&gt;
                 module_src_theme_withZoraThemeScope_tsx module_src_components_pagination_types_ts
                 --&gt; module_src_theme_ZoraBaseProps_ts module_src_components_progress_meta_ts
+                --&gt; module_src_internal_colorModel_ts module_src_components_progress_meta_ts
                 --&gt; module_src_metadata_index_ts module_src_components_progress_Progress_tsx
                 --&gt; module_src_components_progress_resolveProgressFraction_ts
                 module_src_components_progress_Progress_tsx --&gt;
@@ -49486,6 +49492,7 @@ graph LR
   module_src_components_pagination_Pagination_tsx --&gt; module_src_foundation_index_ts
   module_src_components_pagination_Pagination_tsx --&gt; module_src_theme_withZoraThemeScope_tsx
   module_src_components_pagination_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
+  module_src_components_progress_meta_ts --&gt; module_src_internal_colorModel_ts
   module_src_components_progress_meta_ts --&gt; module_src_metadata_index_ts
   module_src_components_progress_Progress_tsx --&gt; module_src_components_progress_resolveProgressFraction_ts
   module_src_components_progress_Progress_tsx --&gt; module_src_components_progress_types_ts

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -12,7 +12,7 @@
     {
       "id": "npm",
       "label": "npm",
-      "value": "v2.5.5",
+      "value": "v2.6.0",
       "color": "cb3837"
     },
     {
@@ -1137,7 +1137,7 @@
     {
       "path": "src/components/progress/meta.ts",
       "isEntrypoint": false,
-      "dependencies": ["src/metadata/index.ts"],
+      "dependencies": ["src/internal/colorModel.ts", "src/metadata/index.ts"],
       "exports": ["progressMeta"]
     },
     {
@@ -43219,6 +43219,11 @@
         "fromPath": "src/components/progress/index.ts",
         "toPath": "src/components/progress/types.ts",
         "sourcePath": "src/components/progress/index.ts"
+      },
+      {
+        "fromPath": "src/components/progress/meta.ts",
+        "toPath": "src/internal/colorModel.ts",
+        "sourcePath": "src/components/progress/meta.ts"
       },
       {
         "fromPath": "src/components/progress/meta.ts",

--- a/src/components/progress/meta.ts
+++ b/src/components/progress/meta.ts
@@ -1,10 +1,46 @@
+import { ZORA_COLORS } from '../../internal/colorModel';
 import type { ZoraComponentMeta } from '../../metadata';
 
 export const progressMeta = {
   name: 'Progress',
   category: 'component',
-  directManifestNode: false,
+  directManifestNode: true,
   allowedChildren: [],
-  note: 'Feedback component; not represented as a manifest node in v1.',
-  props: {},
+  blueprint: {
+    label: 'Progress',
+    defaultProps: {
+      value: 50,
+      max: 100,
+      color: 'primary',
+      size: 'm',
+    },
+  },
+  props: {
+    value: {
+      type: 'number',
+      category: 'State',
+      label: 'Value',
+      default: 50,
+    },
+    max: {
+      type: 'number',
+      category: 'State',
+      label: 'Max',
+      default: 100,
+    },
+    color: {
+      type: 'enum',
+      category: 'Style',
+      label: 'Color',
+      enum: [...ZORA_COLORS],
+      default: 'primary',
+    },
+    size: {
+      type: 'enum',
+      category: 'Style',
+      label: 'Size',
+      enum: ['s', 'm', 'l'],
+      default: 'm',
+    },
+  },
 } as const satisfies ZoraComponentMeta;

--- a/src/metadata/componentMeta.test.ts
+++ b/src/metadata/componentMeta.test.ts
@@ -177,6 +177,7 @@ describe('ZORA_COMPONENT_META invariants', () => {
       'Heading',
       'Divider',
       'ChatListItem',
+      'Progress',
     ]);
 
     const expectedContainerNodes = new Set([
@@ -215,6 +216,17 @@ describe('ZORA_COMPONENT_META invariants', () => {
         `Direct manifest node '${key}' must be categorized as leaf or container in the test.`,
       );
     }
+  });
+
+  test('Progress is a direct manifest leaf with serializable defaults', () => {
+    expect(ZORA_COMPONENT_META.Progress.directManifestNode).toBe(true);
+    expect(ZORA_COMPONENT_META.Progress.allowedChildren).toEqual([]);
+    expect(ZORA_COMPONENT_META.Progress.blueprint?.defaultProps).toEqual({
+      value: 50,
+      max: 100,
+      color: 'primary',
+      size: 'm',
+    });
   });
 
   test('non-direct manifest nodes include an explicit note', () => {


### PR DESCRIPTION
## Summary

Closes #243.

Registers `Progress` as a direct manifest-capable ZORA component so generated manifests can safely reference it.

- sets `Progress.directManifestNode` to `true`
- adds serializable metadata props for `value`, `max`, `color`, and `size`
- adds blueprint defaults for authoring/metadata consumers
- adds metadata invariant coverage that treats `Progress` as a direct manifest leaf
- adds a patch changeset

## Validation

Not run locally in this environment. Please run:

```bash
bun run build
bun run lint:fix
bun run test
bun run knip
```

## Related

- Templates follow-up waiting for this release: ankhorage/templates#73