### PR TITLE
Fix DisclosureSection header trigger and long text layout

### DIFF
--- a/.changeset/fix-disclosure-section-header-layout.md
+++ b/.changeset/fix-disclosure-section-header-layout.md
@@ -1,0 +1,5 @@
+---
+'@ankhorage/zora': patch
+---
+
+Fix `DisclosureSection` header interaction and long-description layout so the main header area toggles open/closed, long text wraps, and the trailing chevron remains visible.

--- a/paradox/components.md
+++ b/paradox/components.md
@@ -811,7 +811,7 @@ Export paths: `src/index.ts`
 
 ## DisclosureSection
 
-Source: `src/patterns/disclosure-section/DisclosureSection.tsx:71:14`
+Source: `src/patterns/disclosure-section/DisclosureSection.tsx:117:14`
 
 Expandable section pattern with a summary header and collapsible content.
 

--- a/paradox/diagrams/architecture-overview.mmd
+++ b/paradox/diagrams/architecture-overview.mmd
@@ -1093,7 +1093,9 @@ graph TD
   module_src_patterns_confirm_dialog_types_ts --> module_src_theme_ZoraBaseProps_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx["src/patterns/disclosure-section/DisclosureSection.tsx"]
   package__ankhorage_zora -.-> module_src_patterns_disclosure_section_DisclosureSection_tsx
+  module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_components_heading_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_components_icon_button_index_ts
+  module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_components_text_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_foundation_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_patterns_disclosure_section_types_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_patterns_panel_index_ts

--- a/paradox/diagrams/module-relationships.mmd
+++ b/paradox/diagrams/module-relationships.mmd
@@ -954,7 +954,9 @@ graph LR
   module_src_patterns_confirm_dialog_meta_ts --> module_src_metadata_index_ts
   module_src_patterns_confirm_dialog_types_ts --> module_src_internal_recipes_ts
   module_src_patterns_confirm_dialog_types_ts --> module_src_theme_ZoraBaseProps_ts
+  module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_components_heading_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_components_icon_button_index_ts
+  module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_components_text_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_foundation_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_patterns_disclosure_section_types_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --> module_src_patterns_panel_index_ts

--- a/paradox/exports.json
+++ b/paradox/exports.json
@@ -5497,7 +5497,7 @@
     "modulePath": "src/patterns/disclosure-section/DisclosureSection.tsx",
     "sourceLocation": {
       "filePath": "src/patterns/disclosure-section/DisclosureSection.tsx",
-      "line": 71,
+      "line": 117,
       "column": 14
     },
     "exportPaths": ["src/index.ts"],

--- a/paradox/exports.md
+++ b/paradox/exports.md
@@ -1294,7 +1294,7 @@ Source: `src/patterns/auth/oauthProviders.ts:3:14`
 
 Kind: `value`
 Module: `src/patterns/disclosure-section/DisclosureSection.tsx`
-Source: `src/patterns/disclosure-section/DisclosureSection.tsx:71:14`
+Source: `src/patterns/disclosure-section/DisclosureSection.tsx:117:14`
 
 Expandable section pattern with a summary header and collapsible content.
 

--- a/paradox/index.html
+++ b/paradox/index.html
@@ -1020,7 +1020,7 @@
                 data-target="src/patterns/disclosure-section/DisclosureSection.tsx"
               >
                 src/patterns/disclosure-section/DisclosureSection.tsx
-                <small>2 functions</small>
+                <small>3 functions</small>
               </button>
             </li>
             <li>
@@ -4766,13 +4766,14 @@
             </article>
             <article
               class="item"
-              data-search="src/patterns/disclosure-section/DisclosureSection.tsx src/components/icon-button/index.ts src/foundation/index.ts src/patterns/disclosure-section/types.ts src/patterns/panel/index.ts src/theme/withZoraThemeScope.tsx DisclosureSection"
+              data-search="src/patterns/disclosure-section/DisclosureSection.tsx src/components/heading/index.ts src/components/icon-button/index.ts src/components/text/index.ts src/foundation/index.ts src/patterns/disclosure-section/types.ts src/patterns/panel/index.ts src/theme/withZoraThemeScope.tsx DisclosureSection"
             >
               <h3>src/patterns/disclosure-section/DisclosureSection.tsx</h3>
               <p class="muted">Referenced module</p>
               <p>
-                <strong>Dependencies:</strong> <code>src/components/icon-button/index.ts</code>,
-                <code>src/foundation/index.ts</code>,
+                <strong>Dependencies:</strong> <code>src/components/heading/index.ts</code>,
+                <code>src/components/icon-button/index.ts</code>,
+                <code>src/components/text/index.ts</code>, <code>src/foundation/index.ts</code>,
                 <code>src/patterns/disclosure-section/types.ts</code>,
                 <code>src/patterns/panel/index.ts</code>,
                 <code>src/theme/withZoraThemeScope.tsx</code>
@@ -24293,7 +24294,7 @@
               >
                 <h4>DisclosureSection</h4>
                 <p class="muted">
-                  value • <code>src/patterns/disclosure-section/DisclosureSection.tsx:71:14</code>
+                  value • <code>src/patterns/disclosure-section/DisclosureSection.tsx:117:14</code>
                 </p>
                 <p>Expandable section pattern with a summary header and collapsible content.</p>
                 <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
@@ -33764,7 +33765,7 @@
             >
               <h3>DisclosureSection</h3>
               <p class="muted">
-                <code>src/patterns/disclosure-section/DisclosureSection.tsx:71:14</code>
+                <code>src/patterns/disclosure-section/DisclosureSection.tsx:117:14</code>
               </p>
               <p>Expandable section pattern with a summary header and collapsible content.</p>
               <p><strong>Export paths:</strong> <code>src/index.ts</code></p>
@@ -46189,7 +46190,11 @@
                 package__ankhorage_zora -.-&gt;
                 module_src_patterns_disclosure_section_DisclosureSection_tsx
                 module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
+                module_src_components_heading_index_ts
+                module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
                 module_src_components_icon_button_index_ts
+                module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
+                module_src_components_text_index_ts
                 module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
                 module_src_foundation_index_ts
                 module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
@@ -47917,7 +47922,9 @@ graph TD
   module_src_patterns_confirm_dialog_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx[&quot;src/patterns/disclosure-section/DisclosureSection.tsx&quot;]
   package__ankhorage_zora -.-&gt; module_src_patterns_disclosure_section_DisclosureSection_tsx
+  module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_components_heading_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_components_icon_button_index_ts
+  module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_components_text_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_foundation_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_patterns_disclosure_section_types_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_patterns_panel_index_ts
@@ -49534,7 +49541,11 @@ graph TD
                 --&gt; module_src_internal_recipes_ts module_src_patterns_confirm_dialog_types_ts
                 --&gt; module_src_theme_ZoraBaseProps_ts
                 module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
+                module_src_components_heading_index_ts
+                module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
                 module_src_components_icon_button_index_ts
+                module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
+                module_src_components_text_index_ts
                 module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
                 module_src_foundation_index_ts
                 module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt;
@@ -50864,7 +50875,9 @@ graph LR
   module_src_patterns_confirm_dialog_meta_ts --&gt; module_src_metadata_index_ts
   module_src_patterns_confirm_dialog_types_ts --&gt; module_src_internal_recipes_ts
   module_src_patterns_confirm_dialog_types_ts --&gt; module_src_theme_ZoraBaseProps_ts
+  module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_components_heading_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_components_icon_button_index_ts
+  module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_components_text_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_foundation_index_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_patterns_disclosure_section_types_ts
   module_src_patterns_disclosure_section_DisclosureSection_tsx --&gt; module_src_patterns_panel_index_ts
@@ -56611,11 +56624,21 @@ sequenceDiagram
             <h2>src/patterns/disclosure-section/DisclosureSection.tsx</h2>
             <article
               class="item"
+              data-search="getTriggerStyle src/patterns/disclosure-section/DisclosureSection.tsx "
+            >
+              <h3>getTriggerStyle</h3>
+              <p class="muted">
+                <code>src/patterns/disclosure-section/DisclosureSection.tsx:21:7</code>
+              </p>
+              <p class="empty">No description available.</p>
+            </article>
+            <article
+              class="item"
               data-search="DisclosureSectionInner src/patterns/disclosure-section/DisclosureSection.tsx "
             >
               <h3>DisclosureSectionInner</h3>
               <p class="muted">
-                <code>src/patterns/disclosure-section/DisclosureSection.tsx:9:1</code>
+                <code>src/patterns/disclosure-section/DisclosureSection.tsx:34:1</code>
               </p>
               <p class="empty">No description available.</p>
             </article>
@@ -56625,7 +56648,7 @@ sequenceDiagram
             >
               <h3>toggleOpen</h3>
               <p class="muted">
-                <code>src/patterns/disclosure-section/DisclosureSection.tsx:28:9</code>
+                <code>src/patterns/disclosure-section/DisclosureSection.tsx:55:9</code>
               </p>
               <p class="empty">No description available.</p>
             </article>

--- a/paradox/paradox.json
+++ b/paradox/paradox.json
@@ -2758,7 +2758,9 @@
       "path": "src/patterns/disclosure-section/DisclosureSection.tsx",
       "isEntrypoint": false,
       "dependencies": [
+        "src/components/heading/index.ts",
         "src/components/icon-button/index.ts",
+        "src/components/text/index.ts",
         "src/foundation/index.ts",
         "src/patterns/disclosure-section/types.ts",
         "src/patterns/panel/index.ts",
@@ -9332,7 +9334,7 @@
       "modulePath": "src/patterns/disclosure-section/DisclosureSection.tsx",
       "sourceLocation": {
         "filePath": "src/patterns/disclosure-section/DisclosureSection.tsx",
-        "line": 71,
+        "line": 117,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -28506,7 +28508,7 @@
       "modulePath": "src/patterns/disclosure-section/DisclosureSection.tsx",
       "sourceLocation": {
         "filePath": "src/patterns/disclosure-section/DisclosureSection.tsx",
-        "line": 71,
+        "line": 117,
         "column": 14
       },
       "exportPaths": ["src/index.ts"],
@@ -40180,11 +40182,20 @@
       }
     },
     {
+      "name": "getTriggerStyle",
+      "description": null,
+      "sourceLocation": {
+        "filePath": "src/patterns/disclosure-section/DisclosureSection.tsx",
+        "line": 21,
+        "column": 7
+      }
+    },
+    {
       "name": "DisclosureSectionInner",
       "description": null,
       "sourceLocation": {
         "filePath": "src/patterns/disclosure-section/DisclosureSection.tsx",
-        "line": 9,
+        "line": 34,
         "column": 1
       }
     },
@@ -40193,7 +40204,7 @@
       "description": null,
       "sourceLocation": {
         "filePath": "src/patterns/disclosure-section/DisclosureSection.tsx",
-        "line": 28,
+        "line": 55,
         "column": 9
       }
     },
@@ -45411,7 +45422,17 @@
       },
       {
         "fromPath": "src/patterns/disclosure-section/DisclosureSection.tsx",
+        "toPath": "src/components/heading/index.ts",
+        "sourcePath": "src/patterns/disclosure-section/DisclosureSection.tsx"
+      },
+      {
+        "fromPath": "src/patterns/disclosure-section/DisclosureSection.tsx",
         "toPath": "src/components/icon-button/index.ts",
+        "sourcePath": "src/patterns/disclosure-section/DisclosureSection.tsx"
+      },
+      {
+        "fromPath": "src/patterns/disclosure-section/DisclosureSection.tsx",
+        "toPath": "src/components/text/index.ts",
         "sourcePath": "src/patterns/disclosure-section/DisclosureSection.tsx"
       },
       {
@@ -48927,6 +48948,12 @@
         "fromSymbol": "toggleOpen",
         "toSymbol": "setInternalOpen",
         "callExpression": "setInternalOpen",
+        "sourcePath": "src/patterns/disclosure-section/DisclosureSection.tsx"
+      },
+      {
+        "fromSymbol": "DisclosureSectionInner",
+        "toSymbol": "getTriggerStyle",
+        "callExpression": "getTriggerStyle",
         "sourcePath": "src/patterns/disclosure-section/DisclosureSection.tsx"
       },
       {

--- a/src/components/card/types.ts
+++ b/src/components/card/types.ts
@@ -7,9 +7,4 @@ import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 export interface CardProps
   extends ZoraBaseProps, Omit<SurfaceCardProps, 'children' | 'p' | 'radius' | 'variant'> {
   children?: React.ReactNode;
-  title?: React.ReactNode;
-  description?: React.ReactNode;
-  eyebrow?: React.ReactNode;
-  actions?: React.ReactNode;
-  footer?: React.ReactNode;
-  tone?:
+  title?: React.React

--- a/src/components/card/types.ts
+++ b/src/components/card/types.ts
@@ -7,4 +7,6 @@ import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 export interface CardProps
   extends ZoraBaseProps, Omit<SurfaceCardProps, 'children' | 'p' | 'radius' | 'variant'> {
   children?: React.ReactNode;
-  title
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  eyebrow?: React

--- a/src/components/card/types.ts
+++ b/src/components/card/types.ts
@@ -6,6 +6,4 @@ import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 
 export interface CardProps
   extends ZoraBaseProps, Omit<SurfaceCardProps, 'children' | 'p' | 'radius' | 'variant'> {
-  children?: React.ReactNode;
-  title?: React.ReactNode;
-  description?:
+  children?: React.ReactNode

--- a/src/components/card/types.ts
+++ b/src/components/card/types.ts
@@ -7,11 +7,4 @@ import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 export interface CardProps
   extends ZoraBaseProps, Omit<SurfaceCardProps, 'children' | 'p' | 'radius' | 'variant'> {
   children?: React.ReactNode;
-  title?: React.ReactNode;
-  description?: React.ReactNode;
-  eyebrow?: React.ReactNode;
-  actions?: React.ReactNode;
-  footer?: React.ReactNode;
-  tone?: ZoraCardTone;
-  compact?: boolean;
-}
+  title

--- a/src/components/card/types.ts
+++ b/src/components/card/types.ts
@@ -8,5 +8,4 @@ export interface CardProps
   extends ZoraBaseProps, Omit<SurfaceCardProps, 'children' | 'p' | 'radius' | 'variant'> {
   children?: React.ReactNode;
   title?: React.ReactNode;
-  description?: React.ReactNode;
-  eyebrow?: React
+  description?:

--- a/src/components/card/types.ts
+++ b/src/components/card/types.ts
@@ -9,4 +9,7 @@ export interface CardProps
   children?: React.ReactNode;
   title?: React.ReactNode;
   description?: React.ReactNode;
-  eyebrow
+  eyebrow?: React.ReactNode;
+  actions?: React.ReactNode;
+  footer?: React.ReactNode;
+  tone?:

--- a/src/components/card/types.ts
+++ b/src/components/card/types.ts
@@ -6,4 +6,7 @@ import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 
 export interface CardProps
   extends ZoraBaseProps, Omit<SurfaceCardProps, 'children' | 'p' | 'radius' | 'variant'> {
-  children?: React.ReactNode
+  children?: React.ReactNode;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  eyebrow

--- a/src/components/card/types.ts
+++ b/src/components/card/types.ts
@@ -7,4 +7,11 @@ import type { ZoraBaseProps } from '../../theme/ZoraBaseProps';
 export interface CardProps
   extends ZoraBaseProps, Omit<SurfaceCardProps, 'children' | 'p' | 'radius' | 'variant'> {
   children?: React.ReactNode;
-  title?: React.React
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  eyebrow?: React.ReactNode;
+  actions?: React.ReactNode;
+  footer?: React.ReactNode;
+  tone?: ZoraCardTone;
+  compact?: boolean;
+}

--- a/src/patterns/disclosure-section/DisclosureSection.tsx
+++ b/src/patterns/disclosure-section/DisclosureSection.tsx
@@ -1,10 +1,35 @@
 import React from 'react';
+import { Platform, Pressable, type ViewStyle } from 'react-native';
 
+import { Heading } from '../../components/heading';
 import { IconButton } from '../../components/icon-button';
+import { Text } from '../../components/text';
 import { Box, Stack } from '../../foundation';
 import { withZoraThemeScope } from '../../theme/withZoraThemeScope';
 import { Panel } from '../panel';
 import type { DisclosureSectionProps } from './types';
+
+const triggerTextStyle: ViewStyle = {
+  flex: 1,
+  minWidth: 0,
+};
+
+const trailingStyle: ViewStyle = {
+  flexShrink: 0,
+};
+
+const getTriggerStyle = (disabled?: boolean): ViewStyle =>
+  ({
+    alignSelf: 'stretch',
+    flex: 1,
+    justifyContent: 'center',
+    minWidth: 0,
+    ...(Platform.OS === 'web'
+      ? {
+          cursor: disabled ? 'default' : 'pointer',
+        }
+      : null),
+  }) as ViewStyle;
 
 function DisclosureSectionInner({
   themeId: _themeId,
@@ -24,6 +49,8 @@ function DisclosureSectionInner({
 
   const isControlled = controlledOpen !== undefined;
   const isOpen = isControlled ? controlledOpen : internalOpen;
+  const titleLabel = typeof title === 'string' || typeof title === 'number' ? `: ${title}` : '';
+  const toggleLabel = `${isOpen ? 'Collapse' : 'Expand'} section${titleLabel}`;
 
   const toggleOpen = () => {
     if (disabled) return;
@@ -37,28 +64,47 @@ function DisclosureSectionInner({
   };
 
   return (
-    <Panel
-      compact
-      description={description}
-      testID={testID}
-      title={title}
-      eyebrow={icon ? <Box pb="xs">{/* Surface icon spec would go here */}</Box> : null}
-      actions={
-        <Stack direction="row" gap="xs" align="center">
-          {actions}
-          <IconButton
-            icon={{ name: isOpen ? 'chevron-up-outline' : 'chevron-down-outline' }}
-            label={isOpen ? 'Collapse' : 'Expand'}
-            variant="ghost"
-            color="neutral"
-            size="s"
+    <Panel compact testID={testID}>
+      <Stack gap="s">
+        <Stack direction="row" gap="m" align="center">
+          <Pressable
+            accessibilityLabel={toggleLabel}
+            accessibilityRole="button"
+            accessibilityState={{ disabled, expanded: isOpen }}
             disabled={disabled}
             onPress={toggleOpen}
-          />
+            style={getTriggerStyle(disabled)}
+          >
+            <Box style={triggerTextStyle}>
+              <Stack gap="xs">
+                {icon ? <Box pb="xs">{/* Surface icon spec would go here */}</Box> : null}
+                <Heading level={4}>{title}</Heading>
+                {description ? (
+                  <Text emphasis="muted" variant="bodySmall">
+                    {description}
+                  </Text>
+                ) : null}
+              </Stack>
+            </Box>
+          </Pressable>
+
+          {actions ? <Box style={trailingStyle}>{actions}</Box> : null}
+
+          <Box style={trailingStyle}>
+            <IconButton
+              icon={{ name: isOpen ? 'chevron-up-outline' : 'chevron-down-outline' }}
+              label={isOpen ? 'Collapse' : 'Expand'}
+              variant="ghost"
+              color="neutral"
+              size="s"
+              disabled={disabled}
+              onPress={toggleOpen}
+            />
+          </Box>
         </Stack>
-      }
-    >
-      {isOpen ? <Box pt="m">{children}</Box> : null}
+
+        {isOpen ? <Box pt="m">{children}</Box> : null}
+      </Stack>
     </Panel>
   );
 }
@@ -66,6 +112,6 @@ function DisclosureSectionInner({
 /***
  * Expandable section pattern with a summary header and collapsible content.
  *
- 
+
  */
 export const DisclosureSection = withZoraThemeScope(DisclosureSectionInner);


### PR DESCRIPTION
Closes #251

## Summary

- Makes the whole visible `DisclosureSection` header act as the expand/collapse trigger.
- Keeps header actions independently clickable without accidentally toggling the section.
- Fixes long eyebrow/title/description text so it wraps instead of clipping.
- Ensures the trailing chevron remains visible and is not pushed off-screen by long text.

## Notes

- The header text column is allowed to shrink/wrap.
- The trailing icon/action area remains non-shrinking.
- A patch changeset is included.

## Testing

- [x] `bun run lint`
- [x] `bun run typecheck`